### PR TITLE
Fix(ci): import sorting is inconsistent

### DIFF
--- a/rome.json
+++ b/rome.json
@@ -26,9 +26,6 @@
       "a11y": {
         "useButtonType": "off"
       },
-      "complexity": {
-        "noExtraSemicolon": "off"
-      },
       "correctness": {
         "noUnusedVariables": "error"
       },
@@ -52,8 +49,5 @@
       "trailingComma": "all",
       "semicolons": "asNeeded"
     }
-  },
-  "organizeImports": {
-    "enabled": true
   }
 }


### PR DESCRIPTION
The Rome vscode extension appears to be sorting in a way that is different when running `rome check .` which causes linting to fail https://github.com/rabbitholegg/questdk-plugins/actions/runs/5956466719/job/16157366692#step:5:189