### PR TITLE
Fix(tsconfig): change base module resolution

### DIFF
--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -21,8 +21,7 @@
     "verbatimModuleSyntax": true,
     "importHelpers": true,
 
-    "moduleResolution": "NodeNext",
-    "module": "ESNext",
+    "moduleResolution": "node",
     "target": "ES2021",
     "lib": ["ES2022", "DOM"],
 


### PR DESCRIPTION
Fixes our remote build issues by setting default `moduleResolution` to `node` instead of `NodeNext`