### PR TITLE
fix(okutrade): convert V3 token addresses to lowercase

### DIFF
--- a/.changeset/modern-days-change.md
+++ b/.changeset/modern-days-change.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-okutrade": patch
+---
+
+fix casing issue with token addresses

--- a/packages/okutrade/src/utils.ts
+++ b/packages/okutrade/src/utils.ts
@@ -60,12 +60,12 @@ export const buildV3PathQuery = (tokenIn?: string, tokenOut?: string) => {
   const conditions: FilterOperator[] = []
 
   if (tokenIn) {
-    conditions.push({ $regex: `^${tokenIn}` })
+    conditions.push({ $regex: `^${tokenIn.toLowerCase()}` })
   }
 
   if (tokenOut) {
     // Chop the 0x prefix before comparing
-    conditions.push({ $regex: `${tokenOut.slice(2)}$` })
+    conditions.push({ $regex: `${tokenOut.toLowerCase().slice(2)}$` })
   }
 
   return {


### PR DESCRIPTION
This PR fixes an issue where some token swaps were not being detected due to a casing issues.