### PR TITLE
fix(uniswap): fix casing issue with tokens on V3 swaps

### DIFF
--- a/.changeset/neat-teachers-chew.md
+++ b/.changeset/neat-teachers-chew.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-uniswap": patch
+---
+
+fix casing issue with token on V3 swaps

--- a/packages/uniswap/src/Uniswap.test.ts
+++ b/packages/uniswap/src/Uniswap.test.ts
@@ -1,6 +1,7 @@
 import { GreaterThanOrEqual, apply } from '@rabbitholegg/questdk/filter'
 import { describe, expect, test } from 'vitest'
 import { getSupportedTokenAddresses, swap } from './Uniswap.js'
+import { getAddress, type Address } from 'viem'
 import {
   CHAIN_ID_ARRAY,
   EXECUTE_ABI_FRAGMENTS,
@@ -82,6 +83,24 @@ describe('Given the uniswap plugin', () => {
           const filter = await swap(params)
           expect(apply(transaction, filter)).to.be.true
         })
+      })
+
+      test('when tokenIn is checksummed', async () => {
+        const { transaction, params } = passingTestCases[1]
+        const filter = await swap({
+          ...params,
+          tokenIn: getAddress(params.tokenIn as Address),
+        })
+        expect(apply(transaction, filter)).to.be.true
+      })
+
+      test('when tokenOut is checksummed', async () => {
+        const { transaction, params } = passingTestCases[0]
+        const filter = await swap({
+          ...params,
+          tokenOut: getAddress(params.tokenOut as Address),
+        })
+        expect(apply(transaction, filter)).to.be.true
       })
     })
 

--- a/packages/uniswap/src/utils.ts
+++ b/packages/uniswap/src/utils.ts
@@ -68,12 +68,12 @@ export const buildV3PathQuery = (tokenIn?: string, tokenOut?: string) => {
   const conditions: FilterOperator[] = []
 
   if (tokenIn) {
-    conditions.push({ $regex: `^${tokenIn}` })
+    conditions.push({ $regex: `^${tokenIn.toLowerCase()}` })
   }
 
   if (tokenOut) {
     // Chop the 0x prefix before comparing
-    conditions.push({ $regex: `${tokenOut.slice(2)}$` })
+    conditions.push({ $regex: `${tokenOut.toLowerCase().slice(2)}$` })
   }
 
   return {


### PR DESCRIPTION

This PR fixes an issue where some token swaps were not being detected due to a casing issue.