### PR TITLE
Fix(gmx): remove V1 support

### DIFF
--- a/.changeset/rotten-bees-battle.md
+++ b/.changeset/rotten-bees-battle.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-gmx": minor
+---
+
+remove V1 from GMX plugin

--- a/packages/gmx/src/GMX.test.ts
+++ b/packages/gmx/src/GMX.test.ts
@@ -22,7 +22,7 @@ describe('Given the gmx plugin', () => {
       test('when swapping tokens', async () => {
         const filter = await swap({
           chainId: ARB_ONE_CHAIN_ID,
-          contractAddress: GMX_ROUTERV1_ADDRESS,
+          contractAddress: GMX_ROUTERV2_ADDRESS,
           tokenIn: Tokens.USDCe,
           tokenOut: Tokens.USDT,
           amountIn: GreaterThanOrEqual(100000n),
@@ -34,7 +34,6 @@ describe('Given the gmx plugin', () => {
           chainId: ARB_ONE_CHAIN_ID,
           to: {
             $or: [
-              GMX_ROUTERV1_ADDRESS.toLowerCase(),
               GMX_ROUTERV2_ADDRESS.toLowerCase(),
             ],
           },

--- a/packages/gmx/src/GMX.test.ts
+++ b/packages/gmx/src/GMX.test.ts
@@ -33,9 +33,7 @@ describe('Given the gmx plugin', () => {
         expect(filter).to.deep.equal({
           chainId: ARB_ONE_CHAIN_ID,
           to: {
-            $or: [
-              GMX_ROUTERV2_ADDRESS.toLowerCase(),
-            ],
+            $or: [GMX_ROUTERV2_ADDRESS.toLowerCase()],
           },
           input: {
             $or: [

--- a/packages/gmx/src/GMX.test.ts
+++ b/packages/gmx/src/GMX.test.ts
@@ -6,12 +6,9 @@ import { ARB_ONE_CHAIN_ID } from './chain-ids.js'
 import { Tokens } from './utils.js'
 import {
   DEFAULT_TOKEN_LIST,
-  GMX_ROUTERV1_ADDRESS,
   GMX_ROUTERV2_ADDRESS,
 } from './contract-addresses.js'
 import {
-  passingTestCasesV1,
-  failingTestCasesV1,
   passingTestCasesV2,
   failingTestCasesV2,
 } from './test-setup.js'
@@ -77,26 +74,6 @@ describe('Given the gmx plugin', () => {
               },
             ],
           },
-        })
-      })
-    })
-
-    describe('should pass filter with valid V1 transactions', () => {
-      passingTestCasesV1.forEach((testCase) => {
-        const { transaction, params, description } = testCase
-        test(description, async () => {
-          const filter = await swap({ ...params })
-          expect(apply(transaction, filter)).to.be.true
-        })
-      })
-    })
-
-    describe('should not pass filter with invalid V1 transactions', () => {
-      failingTestCasesV1.forEach((testCase) => {
-        const { transaction, params, description } = testCase
-        test(description, async () => {
-          const filter = await swap({ ...params })
-          expect(apply(transaction, filter)).to.be.false
         })
       })
     })

--- a/packages/gmx/src/GMX.ts
+++ b/packages/gmx/src/GMX.ts
@@ -44,9 +44,7 @@ export const swap = async (
     chainId: chainId,
     value: ETH_USED ? amountIn : undefined,
     to: {
-      $or: [
-        GMX_ROUTERV2_ADDRESS.toLowerCase(),
-      ],
+      $or: [GMX_ROUTERV2_ADDRESS.toLowerCase()],
     },
     input: {
       $or: [

--- a/packages/gmx/src/GMX.ts
+++ b/packages/gmx/src/GMX.ts
@@ -10,7 +10,6 @@ import { ARB_ONE_CHAIN_ID, CHAIN_ID_ARRAY } from './chain-ids.js'
 import { GMX_SWAPV1_ABI, GMX_SWAPV2_ABI } from './abi.js'
 import {
   DEFAULT_TOKEN_LIST,
-  GMX_ROUTERV1_ADDRESS,
   GMX_ROUTERV2_ADDRESS,
   ETH_ADDRESS,
   MARKET_TOKENS,
@@ -46,7 +45,6 @@ export const swap = async (
     value: ETH_USED ? amountIn : undefined,
     to: {
       $or: [
-        GMX_ROUTERV1_ADDRESS.toLowerCase(),
         GMX_ROUTERV2_ADDRESS.toLowerCase(),
       ],
     },


### PR DESCRIPTION
I left the arrays and the constants in place just so it's easy to expand support in the future.