### PR TITLE
fix(zora): fix casing issue with token addresses when using arrays

### DIFF
--- a/.changeset/calm-tigers-rescue.md
+++ b/.changeset/calm-tigers-rescue.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-zora": patch
+---
+
+fix casing issue with contract address

--- a/packages/zora/src/Zora.ts
+++ b/packages/zora/src/Zora.ts
@@ -19,7 +19,7 @@ export const mint = async (
   ].toLowerCase() as Address
 
   const mintContract = universalMinter
-    ? { $or: [contractAddress, universalMinter] }
+    ? { $or: [contractAddress.toLowerCase(), universalMinter] }
     : contractAddress
 
   const andArray = []

--- a/packages/zora/src/test-setup.ts
+++ b/packages/zora/src/test-setup.ts
@@ -1,3 +1,4 @@
+import { getAddress } from 'viem'
 import { createTestCase } from './utils'
 import {
   BASIC_PURCHASE,
@@ -11,6 +12,9 @@ export const passingTestCases = [
   createTestCase(MINT_WITH_REWARDS, 'Minting with rewards'),
   createTestCase(MINT_WITH_REWARDS_1155, 'Minting with rewards 1155'),
   createTestCase(MINT_BATCH_WITHOUT_FEES, 'When using the batch mint function'),
+  createTestCase(MINT_WITH_REWARDS, 'when contractAddress is checksummed', {
+    contractAddress: getAddress(MINT_WITH_REWARDS.params.contractAddress),
+  }),
 ]
 
 export const failingTestCases = [


### PR DESCRIPTION
This pr fixes a bug in the zora plugin where token addresses are not being recognized due to a casing issue