### PR TITLE
fix(zora): assure `universalMinter` is defined before using string methods

### DIFF
--- a/.changeset/soft-mice-film.md
+++ b/.changeset/soft-mice-film.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-zora": patch
+---
+
+assure universal minter address is defined before using string methods

--- a/packages/zora/src/Zora.ts
+++ b/packages/zora/src/Zora.ts
@@ -16,10 +16,10 @@ export const mint = async (
 
   const universalMinter = zoraUniversalMinterAddress[
     chainId as Chains
-  ].toLowerCase() as Address
+  ]
 
   const mintContract = universalMinter
-    ? { $or: [contractAddress.toLowerCase(), universalMinter] }
+    ? { $or: [contractAddress.toLowerCase(), universalMinter.toLowerCase()] }
     : contractAddress
 
   const andArray = []


### PR DESCRIPTION
This PR fixes an issue where the plugin can will crash if `universalMinter` is undefined and the string method `.toLowerCase()` is called.