### PR TITLE
Fix(zora): 721 vs 1155 and empty $and

### DIFF
--- a/.changeset/dry-kiwis-speak.md
+++ b/.changeset/dry-kiwis-speak.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-zora": minor
+---
+
+Fix issues with 721 vs 1155 collections and empty $and array

--- a/packages/zora/src/Zora.test.ts
+++ b/packages/zora/src/Zora.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest'
 import { failingTestCases, passingTestCases } from './test-setup'
 import { BASIC_PURCHASE } from './test-transactions'
 import { mint } from './Zora'
-import { ZORA_MINTER_ABI } from './abi'
+import { ZORA_MINTER_ABI_1155, ZORA_MINTER_ABI_721 } from './abi'
 
 describe('Given the zora plugin', () => {
   describe('When handling the mint', () => {
@@ -19,18 +19,40 @@ describe('Given the zora plugin', () => {
           ],
         },
         input: {
-          $abiAbstract: ZORA_MINTER_ABI,
-          $and: [
+          $or: [
             {
-              $or: [
+              $abiAbstract: ZORA_MINTER_ABI_721,
+              $and: [
                 {
-                  recipient: '0x628d4c61d81ac4f286b1778a063ed2f8810bc367',
+                  $or: [
+                    {
+                      recipient: '0x628d4c61d81ac4f286b1778a063ed2f8810bc367',
+                    },
+                    {
+                      tokenRecipient: '0x628d4c61d81ac4f286b1778a063ed2f8810bc367',
+                    },
+                    {
+                      to: '0x628d4c61d81ac4f286b1778a063ed2f8810bc367',
+                    },
+                  ],
                 },
+              ],
+            },
+            {
+              $abiAbstract: ZORA_MINTER_ABI_1155,
+              $and: [
                 {
-                  tokenRecipient: '0x628d4c61d81ac4f286b1778a063ed2f8810bc367',
-                },
-                {
-                  to: '0x628d4c61d81ac4f286b1778a063ed2f8810bc367',
+                  $or: [
+                    {
+                      recipient: '0x628d4c61d81ac4f286b1778a063ed2f8810bc367',
+                    },
+                    {
+                      tokenRecipient: '0x628d4c61d81ac4f286b1778a063ed2f8810bc367',
+                    },
+                    {
+                      to: '0x628d4c61d81ac4f286b1778a063ed2f8810bc367',
+                    },
+                  ],
                 },
               ],
             },

--- a/packages/zora/src/Zora.ts
+++ b/packages/zora/src/Zora.ts
@@ -56,6 +56,7 @@ export const mint = async (
           $and: andArray1155.length !== 0 ? andArray1155 : undefined,
         },
       ],
+    },
   })
 }
 

--- a/packages/zora/src/Zora.ts
+++ b/packages/zora/src/Zora.ts
@@ -6,7 +6,7 @@ import {
 import { zoraUniversalMinterAddress } from '@zoralabs/universal-minter'
 import { type Address } from 'viem'
 import { CHAIN_ID_ARRAY } from './chain-ids'
-import { ZORA_MINTER_ABI } from './abi'
+import {  ZORA_MINTER_ABI_1155, ZORA_MINTER_ABI_721 } from './abi'
 import type { Chains } from './utils'
 
 export const mint = async (
@@ -22,16 +22,23 @@ export const mint = async (
     ? { $or: [contractAddress.toLowerCase(), universalMinter] }
     : contractAddress
 
-  const andArray = []
+  const andArray721 = []
+  const andArray1155 = []
   if (recipient) {
-    andArray.push({
+    andArray721.push({
+      $or: [{ recipient }, { tokenRecipient: recipient }, { to: recipient }],
+    })
+    andArray1155.push({
       $or: [{ recipient }, { tokenRecipient: recipient }, { to: recipient }],
     })
   }
   if (tokenId || amount) {
-    andArray.push({
+    andArray721.push({
       quantity: amount,
       tokenId,
+    })
+    andArray1155.push({
+      quantity: amount,
     })
   }
 
@@ -39,9 +46,16 @@ export const mint = async (
     chainId,
     to: mintContract,
     input: {
-      $abiAbstract: ZORA_MINTER_ABI,
-      $and: andArray,
-    },
+      $or: [
+       {
+        $abiAbstract: ZORA_MINTER_ABI_721,
+        $and: andArray721.length !== 0 ? andArray721 : undefined,
+       },
+        {
+          $abiAbstract: ZORA_MINTER_ABI_1155,
+          $and: andArray1155.length !== 0 ? andArray1155 : undefined,
+        },
+      ],
   })
 }
 

--- a/packages/zora/src/Zora.ts
+++ b/packages/zora/src/Zora.ts
@@ -35,10 +35,10 @@ export const mint = async (
   if (tokenId || amount) {
     andArray721.push({
       quantity: amount,
-      tokenId,
     })
     andArray1155.push({
       quantity: amount,
+      tokenId,
     })
   }
 

--- a/packages/zora/src/abi.ts
+++ b/packages/zora/src/abi.ts
@@ -1,4 +1,4 @@
-export const ZORA_MINTER_ABI = [
+export const ZORA_MINTER_ABI_721 = [
   // https://github.com/ourzora/zora-721-contracts/blob/main/src/ERC721Drop.sol#L384
   {
     inputs: [
@@ -222,8 +222,13 @@ export const ZORA_MINTER_ABI = [
     ],
     stateMutability: 'payable',
     type: 'function',
-  }, // ERC721Drop
+  } // ERC721Drop
   // https://github.com/ourzora/zora-protocol/blob/8d1fe9bdd79a552a8f74b4712451185f6aebf9a0/packages/1155-contracts/src/nft/ZoraCreator1155Impl.sol#L427
+  
+]
+
+
+export const ZORA_MINTER_ABI_1155 = [
   {
     inputs: [
       {


### PR DESCRIPTION
Working theory is that `tokenId` is not defined in the params for 721 collections, this means that when misconfigured a quest targetting a 721 collection with a `tokenId` set will be impossible to complete. This PR addresses that by only filtering based on `tokenId` if the function being called is on an 1155 collection. Also makes sure that the `$and` array get stripped out of the filter if it's empty.