### PR TITLE
chore(symbiosis): pin symbiosis sdk version

### DIFF
--- a/.changeset/seven-bobcats-cover.md
+++ b/.changeset/seven-bobcats-cover.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-symbiosis": patch
+---
+
+pin sdk version

--- a/packages/symbiosis/package.json
+++ b/packages/symbiosis/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@rabbitholegg/questdk": "2.0.0-alpha.28",
     "ethers": "^5.2.0",
-    "symbiosis-js-sdk": "^3.0.9",
+    "symbiosis-js-sdk": "3.0.9",
     "viem": "^1.2.15"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -524,7 +524,7 @@ importers:
       ethers: ^5.2.0
       rimraf: ^5.0.1
       rome: ^12.1.3
-      symbiosis-js-sdk: ^3.0.9
+      symbiosis-js-sdk: 3.0.9
       ts-node: ^10.9.1
       tsconfig: workspace:*
       typescript: ^5.1.6
@@ -533,7 +533,7 @@ importers:
     dependencies:
       '@rabbitholegg/questdk': 2.0.0-alpha.28_typescript@5.3.2
       ethers: 5.7.2
-      symbiosis-js-sdk: 3.1.1_ethers@5.7.2
+      symbiosis-js-sdk: 3.0.9_ethers@5.7.2
       viem: 1.19.11_typescript@5.3.2
     devDependencies:
       '@types/node': 20.10.3
@@ -1581,7 +1581,7 @@ packages:
       '@ethersproject/providers': 5.7.2
       '@ethersproject/web': 5.7.1
       chai: 4.3.10
-      ethers: 5.7.1
+      ethers: 5.7.2
       lodash: 4.17.21
     transitivePeerDependencies:
       - bufferutil
@@ -1759,7 +1759,7 @@ packages:
       '@ledgerhq/hw-app-eth': 5.27.2
       '@ledgerhq/hw-transport': 5.26.0
       '@ledgerhq/hw-transport-u2f': 5.26.0
-      ethers: 5.7.1
+      ethers: 5.7.2
     optionalDependencies:
       '@ledgerhq/hw-transport-node-hid': 5.26.0
     transitivePeerDependencies:
@@ -9271,8 +9271,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /symbiosis-js-sdk/3.1.1_ethers@5.7.2:
-    resolution: {integrity: sha512-VDvWjyFvCVCFHj1zcgXVfllE5m7NPI8KjnbLpAdF8T6/1RDN8XNWJuqW6dGAuMEXC/qhR4LjFa8GeVy0QDaVwA==}
+  /symbiosis-js-sdk/3.0.9_ethers@5.7.2:
+    resolution: {integrity: sha512-jNdOiSiXHIAGgnhDI/KeRVeCNcr284+5ocPOR9ccnvb4ltBb8eA1O+fem2EVrPj/yHxk5weM16vTuparCVNljQ==}
     engines: {node: '>=10'}
     peerDependencies:
       ethers: ^5.2.0


### PR DESCRIPTION
This PR pins the symbiosis-js-sdk package to version 3.0.9. This is a temporary fix until we can add support for their new contracts and abi.