### PR TITLE
Fix(sound&mirror): tweak ABIs and targets to get simulations running

### DIFF
--- a/.changeset/empty-mirrors-act.md
+++ b/.changeset/empty-mirrors-act.md
@@ -1,0 +1,7 @@
+---
+"@rabbitholegg/questdk-plugin-registry": minor
+"@rabbitholegg/questdk-plugin-soundxyz": minor
+"@rabbitholegg/questdk-plugin-mirror": minor
+---
+
+Fix issue with simulated mints for sound and mirror

--- a/packages/mirror/src/Mirror.ts
+++ b/packages/mirror/src/Mirror.ts
@@ -9,6 +9,7 @@ import {
   chainIdToViemChain,
   DEFAULT_ACCOUNT,
   type DisctriminatedActionParams,
+  BOOST_TREASURY_ADDRESS,
 } from '@rabbitholegg/questdk-plugin-utils'
 import {
   type Address,
@@ -24,6 +25,7 @@ import {
   GET_FEE_CONFIGURATION_ABI,
   GET_PLATFORM_FEE_ABI,
   GET_PRICE_ABI,
+  PURCHASE_ABI,
 } from './abi'
 import { Chains } from './utils'
 
@@ -80,9 +82,9 @@ export const simulateMint = async (
   const result = await _client.simulateContract({
     address: contractAddress,
     value,
-    abi: COLLECT_ENTRY_ABI,
+    abi: PURCHASE_ABI,
     functionName: 'purchase',
-    args: [recipient],
+    args: [recipient, '', BOOST_TREASURY_ADDRESS ],
     account: account || DEFAULT_ACCOUNT,
   })
 

--- a/packages/mirror/src/abi.ts
+++ b/packages/mirror/src/abi.ts
@@ -20,7 +20,21 @@ export const COLLECT_ENTRY_ABI = [
     stateMutability: 'payable',
     type: 'function',
   },
-] as const
+]
+
+export const PURCHASE_ABI = [
+  {
+    inputs: [
+      { internalType: 'address', name: 'tokenRecipient', type: 'address' },
+      { internalType: 'string', name: 'message', type: 'string' },
+      { internalType: 'address', name: 'mintReferral', type: 'address' },
+    ],
+    name: 'purchase',
+    outputs: [{ internalType: 'uint256', name: 'tokenId', type: 'uint256' }],
+    stateMutability: 'payable',
+    type: 'function',
+  }
+]
 
 export const GET_PRICE_ABI = [
   {

--- a/packages/mirror/src/abi.ts
+++ b/packages/mirror/src/abi.ts
@@ -20,7 +20,7 @@ export const COLLECT_ENTRY_ABI = [
     stateMutability: 'payable',
     type: 'function',
   },
-]
+] as const
 
 export const GET_PRICE_ABI = [
   {

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -120,15 +120,6 @@ export const getTxSimulation = (
   client?: PublicClient,
   account?: Address,
 ) => {
-  console.log(
-    'getTxSimulation',
-    plugin,
-    actionType,
-    params,
-    value,
-    client,
-    account,
-  )
   switch (actionType) {
     case ActionType.Mint:
       if (plugin.simulateMint !== undefined) {

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -120,6 +120,7 @@ export const getTxSimulation = (
   client?: PublicClient,
   account?: Address,
 ) => {
+  console.log('getTxSimulation', plugin, actionType, params, value, client, account)
   switch (actionType) {
     case ActionType.Mint:
       if (plugin.simulateMint !== undefined) {

--- a/packages/soundxyz/src/Soundxyz.ts
+++ b/packages/soundxyz/src/Soundxyz.ts
@@ -126,7 +126,7 @@ export const simulateMint = async (
     abi: SUPERMINTER_ABI,
     functionName: 'mintTo',
     args: [mintTo],
-    address: contractAddress,
+    address: SUPERMINTER_V2,
     value,
     account: account || DEFAULT_ACCOUNT,
   })

--- a/packages/soundxyz/src/constants.ts
+++ b/packages/soundxyz/src/constants.ts
@@ -46,6 +46,22 @@ export const SUPERMINTER_ABI = [
     stateMutability: 'payable',
     type: 'function',
   },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "paid",
+        type: "uint256"
+      },
+      {
+        internalType: "uint256",
+        name: "required",
+        type: "uint256"
+      }
+    ],
+    name: "WrongPayment",
+    type: "error"
+  }
 ]
 
 export const MINT_INFO_LIST_ABI = [


### PR DESCRIPTION
Mirror is working pretty consistently. I got sound to work by hard coding the value property, but the value we're passing right now isn't working here, so sound mint embeds won't work until that's fixed. The hard coded value I had success with for [this sound](https://www.sound.xyz/notanotherbearbear/krush-sonata) was '777000000000000' but it's the _second_ param of the error that's thrown:

```
metaMessages: [
      'Error: WrongPayment(uint256 paid, uint256 required)',
      '                   (1500000000000000, 777000000000000)'
    ],
```

This `metaMessages` with the qualified error should be thrown to the FE.