### PR TITLE
feat: use github actions to confirm and upload plugin details to db 

### DIFF
--- a/.changeset/khaki-nails-tie.md
+++ b/.changeset/khaki-nails-tie.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/create-plugin": minor
+---
+
+add details questions to builder

--- a/.github/scripts/registerNewPlugins.ts
+++ b/.github/scripts/registerNewPlugins.ts
@@ -1,0 +1,90 @@
+const _axios = require("axios");
+const _fs = require("fs/promises");
+const _yaml = require("js-yaml");
+const _utils = require("./utils");
+
+async function sendPluginDetailsToAPI(detailsPath: string): Promise<void> {
+  const fileContents = await _fs.readFile(detailsPath, "utf8");
+  const details = _yaml.load(fileContents);
+  const { project, tasks } = details;
+
+  // send project details to staging API
+  const { data: stagingData } = await _axios.post(
+    `${process.env.STAGING_API_URL}/plugins/add-project`,
+    {
+      ...project,
+      approvedForTerminal: true,
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.BOOST_API_TOKEN}`,
+      },
+    },
+  );
+
+  // send project details to production API
+  const { data } = await _axios.post(
+    `${process.env.PRODUCTION_API_URL}/plugins/add-project`,
+    project,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.BOOST_API_TOKEN}`,
+      },
+    },
+  );
+
+  for (const task of tasks) {
+    // send task details to staging API
+    await _axios.post(
+      `${process.env.STAGING_API_URL}/plugins/add-task`,
+      {
+        ...task,
+        projectId: stagingData.projectId,
+        approvedForTerminal: true,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${process.env.BOOST_API_TOKEN}`,
+        },
+      },
+    );
+    
+    // send task details to production API
+    await _axios.post(
+      `${process.env.PRODUCTION_API_URL}/plugins/add-task`,
+      {
+        ...task,
+        projectId: data.projectId,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${process.env.BOOST_API_TOKEN}`,
+        },
+      },
+    );
+  }
+
+  console.log(`Successfully registered plugin details for ${project.name}`);
+}
+
+async function _main() {
+  const newPackagesPaths = await _utils.getNewPackages();
+  const updatedDetailsPaths = await _utils.getUpdatedPluginDetailsPaths();
+  const uniqueDetailsPaths = Array.from(
+    new Set([...newPackagesPaths, ...updatedDetailsPaths]),
+  );
+  if (uniqueDetailsPaths.length) {
+    const validDetailsPaths = await _utils.validatePluginDetailsPaths(
+      uniqueDetailsPaths,
+    );
+    for (const detailsPath of validDetailsPaths) {
+      await sendPluginDetailsToAPI(detailsPath);
+    }
+  } else {
+    console.log("No new packages found.");
+  }
+}
+
+_main().catch((error) => {
+  throw new Error(`Error registering plugin details: ${error}`);
+});

--- a/.github/scripts/registerNewPlugins.ts
+++ b/.github/scripts/registerNewPlugins.ts
@@ -1,12 +1,12 @@
-const _axios = require("axios");
-const _fs = require("fs/promises");
-const _yaml = require("js-yaml");
-const _utils = require("./utils");
+const _axios = require('axios')
+const _fs = require('fs/promises')
+const _yaml = require('js-yaml')
+const _utils = require('./utils')
 
 async function sendPluginDetailsToAPI(detailsPath: string): Promise<void> {
-  const fileContents = await _fs.readFile(detailsPath, "utf8");
-  const details = _yaml.load(fileContents);
-  const { project, tasks } = details;
+  const fileContents = await _fs.readFile(detailsPath, 'utf8')
+  const details = _yaml.load(fileContents)
+  const { project, tasks } = details
 
   // send project details to staging API
   const { data: stagingData } = await _axios.post(
@@ -20,7 +20,7 @@ async function sendPluginDetailsToAPI(detailsPath: string): Promise<void> {
         Authorization: `Bearer ${process.env.BOOST_API_TOKEN}`,
       },
     },
-  );
+  )
 
   // send project details to production API
   const { data } = await _axios.post(
@@ -31,7 +31,7 @@ async function sendPluginDetailsToAPI(detailsPath: string): Promise<void> {
         Authorization: `Bearer ${process.env.BOOST_API_TOKEN}`,
       },
     },
-  );
+  )
 
   for (const task of tasks) {
     // send task details to staging API
@@ -47,8 +47,8 @@ async function sendPluginDetailsToAPI(detailsPath: string): Promise<void> {
           Authorization: `Bearer ${process.env.BOOST_API_TOKEN}`,
         },
       },
-    );
-    
+    )
+
     // send task details to production API
     await _axios.post(
       `${process.env.PRODUCTION_API_URL}/plugins/add-task`,
@@ -61,30 +61,30 @@ async function sendPluginDetailsToAPI(detailsPath: string): Promise<void> {
           Authorization: `Bearer ${process.env.BOOST_API_TOKEN}`,
         },
       },
-    );
+    )
   }
 
-  console.log(`Successfully registered plugin details for ${project.name}`);
+  console.log(`Successfully registered plugin details for ${project.name}`)
 }
 
 async function _main() {
-  const newPackagesPaths = await _utils.getNewPackages();
-  const updatedDetailsPaths = await _utils.getUpdatedPluginDetailsPaths();
+  const newPackagesPaths = await _utils.getNewPackages()
+  const updatedDetailsPaths = await _utils.getUpdatedPluginDetailsPaths()
   const uniqueDetailsPaths = Array.from(
     new Set([...newPackagesPaths, ...updatedDetailsPaths]),
-  );
+  )
   if (uniqueDetailsPaths.length) {
     const validDetailsPaths = await _utils.validatePluginDetailsPaths(
       uniqueDetailsPaths,
-    );
+    )
     for (const detailsPath of validDetailsPaths) {
-      await sendPluginDetailsToAPI(detailsPath);
+      await sendPluginDetailsToAPI(detailsPath)
     }
   } else {
-    console.log("No new packages found.");
+    console.log('No new packages found.')
   }
 }
 
 _main().catch((error) => {
-  throw new Error(`Error registering plugin details: ${error}`);
-});
+  throw new Error(`Error registering plugin details: ${error}`)
+})

--- a/.github/scripts/utils.ts
+++ b/.github/scripts/utils.ts
@@ -1,0 +1,74 @@
+const path = require("path");
+const { exec } = require("child_process");
+const file = require("fs/promises");
+const { promisify } = require("util");
+
+const execAsync = promisify(exec);
+
+async function getNewPackages(): Promise<string[]> {
+  // Get list of all directories in packages/ on main
+  const { stdout: mainDirs } = await execAsync(
+    "git ls-tree -d --name-only main:packages/",
+  );
+  const mainPackagesSet = new Set(
+    mainDirs.split("\n").filter((name: string) => name.trim() !== ""),
+  );
+
+  // Get list of all directories in packages/ in the current HEAD
+  const { stdout: headDirs } = await execAsync(
+    "git ls-tree -d --name-only HEAD:packages/",
+  );
+  const headPackages = headDirs
+    .split("\n")
+    .filter((name: string) => name.trim() !== "");
+
+  // Filter out directories that are also present on main
+  const newPackageDirs = headPackages
+    .filter((pkg: string) => !mainPackagesSet.has(pkg))
+    .map((pkg: string) => path.join("packages", pkg));
+
+  return newPackageDirs;
+}
+
+async function getUpdatedPluginDetailsPaths(): Promise<string[]> {
+  // compares the current HEAD with the previous commit to get the updated plugin details
+  const { stdout, stderr } = await execAsync(
+    "git diff --name-only HEAD^ HEAD -- 'packages/*plugin-details.yml'",
+  );
+  if (stderr) {
+    throw new Error(`Error getting updated plugin details: ${stderr}`);
+  }
+  const detailsPaths = stdout
+    .split("\n")
+    .filter(
+      (path: string) =>
+        path.trim() !== "" && path.includes("plugin-details.yml"),
+    )
+    .map((path: string) => path.replace("/plugin-details.yml", "").trim());
+
+  return detailsPaths;
+}
+
+async function validatePluginDetailsPaths(
+  newPackagesPaths: string[],
+): Promise<string[]> {
+  const validDetailsPaths: string[] = [];
+
+  for (const packageDir of newPackagesPaths) {
+    const detailsPath = path.join(packageDir, "plugin-details.yml");
+    try {
+      await file.access(detailsPath);
+      console.log(`Valid: ${detailsPath} exists.`);
+      validDetailsPaths.push(detailsPath);
+    } catch (error) {
+      throw new Error(`Missing plugin-details.yml in package: ${packageDir}`);
+    }
+  }
+  return validDetailsPaths;
+}
+
+module.exports = {
+  getNewPackages,
+  getUpdatedPluginDetailsPaths,
+  validatePluginDetailsPaths,
+};

--- a/.github/scripts/utils.ts
+++ b/.github/scripts/utils.ts
@@ -1,74 +1,74 @@
-const path = require("path");
-const { exec } = require("child_process");
-const file = require("fs/promises");
-const { promisify } = require("util");
+const path = require('path')
+const { exec } = require('child_process')
+const file = require('fs/promises')
+const { promisify } = require('util')
 
-const execAsync = promisify(exec);
+const execAsync = promisify(exec)
 
 async function getNewPackages(): Promise<string[]> {
   // Get list of all directories in packages/ on main
   const { stdout: mainDirs } = await execAsync(
-    "git ls-tree -d --name-only main:packages/",
-  );
+    'git ls-tree -d --name-only main:packages/',
+  )
   const mainPackagesSet = new Set(
-    mainDirs.split("\n").filter((name: string) => name.trim() !== ""),
-  );
+    mainDirs.split('\n').filter((name: string) => name.trim() !== ''),
+  )
 
   // Get list of all directories in packages/ in the current HEAD
   const { stdout: headDirs } = await execAsync(
-    "git ls-tree -d --name-only HEAD:packages/",
-  );
+    'git ls-tree -d --name-only HEAD:packages/',
+  )
   const headPackages = headDirs
-    .split("\n")
-    .filter((name: string) => name.trim() !== "");
+    .split('\n')
+    .filter((name: string) => name.trim() !== '')
 
   // Filter out directories that are also present on main
   const newPackageDirs = headPackages
     .filter((pkg: string) => !mainPackagesSet.has(pkg))
-    .map((pkg: string) => path.join("packages", pkg));
+    .map((pkg: string) => path.join('packages', pkg))
 
-  return newPackageDirs;
+  return newPackageDirs
 }
 
 async function getUpdatedPluginDetailsPaths(): Promise<string[]> {
   // compares the current HEAD with the previous commit to get the updated plugin details
   const { stdout, stderr } = await execAsync(
     "git diff --name-only HEAD^ HEAD -- 'packages/*plugin-details.yml'",
-  );
+  )
   if (stderr) {
-    throw new Error(`Error getting updated plugin details: ${stderr}`);
+    throw new Error(`Error getting updated plugin details: ${stderr}`)
   }
   const detailsPaths = stdout
-    .split("\n")
+    .split('\n')
     .filter(
       (path: string) =>
-        path.trim() !== "" && path.includes("plugin-details.yml"),
+        path.trim() !== '' && path.includes('plugin-details.yml'),
     )
-    .map((path: string) => path.replace("/plugin-details.yml", "").trim());
+    .map((path: string) => path.replace('/plugin-details.yml', '').trim())
 
-  return detailsPaths;
+  return detailsPaths
 }
 
 async function validatePluginDetailsPaths(
   newPackagesPaths: string[],
 ): Promise<string[]> {
-  const validDetailsPaths: string[] = [];
+  const validDetailsPaths: string[] = []
 
   for (const packageDir of newPackagesPaths) {
-    const detailsPath = path.join(packageDir, "plugin-details.yml");
+    const detailsPath = path.join(packageDir, 'plugin-details.yml')
     try {
-      await file.access(detailsPath);
-      console.log(`Valid: ${detailsPath} exists.`);
-      validDetailsPaths.push(detailsPath);
+      await file.access(detailsPath)
+      console.log(`Valid: ${detailsPath} exists.`)
+      validDetailsPaths.push(detailsPath)
     } catch (error) {
-      throw new Error(`Missing plugin-details.yml in package: ${packageDir}`);
+      throw new Error(`Missing plugin-details.yml in package: ${packageDir}`)
     }
   }
-  return validDetailsPaths;
+  return validDetailsPaths
 }
 
 module.exports = {
   getNewPackages,
   getUpdatedPluginDetailsPaths,
   validatePluginDetailsPaths,
-};
+}

--- a/.github/scripts/verifyConfigFileFormat.ts
+++ b/.github/scripts/verifyConfigFileFormat.ts
@@ -1,0 +1,84 @@
+const axios = require("axios");
+const fs = require("fs/promises");
+const zod = require("zod");
+const yaml = require("js-yaml");
+const utils = require("./utils");
+const { z } = zod;
+
+const ProjectConfigSchema = z.object({
+  name: z.string(),
+  iconOption: z.string().url().optional(),
+  appLink: z.string().url().optional(),
+});
+
+const TaskConfigSchema = z.object({
+  name: z.string(),
+  link: z.string().url(),
+  iconOption: z.string().url(),
+  actionPluginId: z.string(),
+});
+
+const PluginConfigSchema = z.object({
+  project: ProjectConfigSchema,
+  tasks: z.array(TaskConfigSchema).nonempty(),
+});
+
+async function validateConfigFile(filePath: string): Promise<void> {
+  try {
+    const configFileContent = await fs.readFile(filePath, "utf8");
+    const config = yaml.load(configFileContent);
+    PluginConfigSchema.parse(config);
+    const { project, tasks } = config;
+
+    for (const task of tasks) {
+      // validate each unique icon option url
+      const uniqueIconOptions = new Set(
+        [project.iconOption, task.iconOption].filter(Boolean),
+      );
+      for (const iconOption of uniqueIconOptions) {
+        await validateIcon(iconOption);
+      }
+    }
+    console.log(`Config in ${filePath} is valid.`);
+  } catch (error) {
+    console.error(`Error validating config in ${filePath}:`, error);
+    process.exit(1);
+  }
+}
+
+async function validateIcon(iconUrl: string) {
+  const response = await axios.post(
+    `${process.env.API_URL}/plugins/validate-icon`,
+    {
+      iconOption: iconUrl,
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.BOOST_API_TOKEN}`,
+      },
+    },
+  );
+  if (response.status === 200) {
+    console.log("Icon is valid:", iconUrl);
+  } else {
+    throw new Error(`Icon validation failed for ${iconUrl}`);
+  }
+}
+
+async function main() {
+  const newPackagesPaths = await utils.getNewPackages();
+  const updatedDetailsPaths = await utils.getUpdatedPluginDetailsPaths();
+  const uniqueDetailsPaths = Array.from(
+    new Set([...newPackagesPaths, ...updatedDetailsPaths]),
+  );
+  if (uniqueDetailsPaths.length) {
+    const paths = await utils.validatePluginDetailsPaths(uniqueDetailsPaths);
+    for (const path of paths) {
+      await validateConfigFile(path);
+    }
+  } else {
+    console.log("No new packages found.");
+  }
+}
+
+main();

--- a/.github/scripts/verifyConfigFileFormat.ts
+++ b/.github/scripts/verifyConfigFileFormat.ts
@@ -48,7 +48,7 @@ async function validateConfigFile(filePath: string): Promise<void> {
 
 async function validateIcon(iconUrl: string) {
   const response = await axios.post(
-    `${process.env.API_URL}/plugins/validate-icon`,
+    `${process.env.BOOST_API}/plugins/validate-icon`,
     {
       iconOption: iconUrl,
     },

--- a/.github/scripts/verifyConfigFileFormat.ts
+++ b/.github/scripts/verifyConfigFileFormat.ts
@@ -1,48 +1,48 @@
-const axios = require("axios");
-const fs = require("fs/promises");
-const zod = require("zod");
-const yaml = require("js-yaml");
-const utils = require("./utils");
-const { z } = zod;
+const axios = require('axios')
+const fs = require('fs/promises')
+const zod = require('zod')
+const yaml = require('js-yaml')
+const utils = require('./utils')
+const { z } = zod
 
 const ProjectConfigSchema = z.object({
   name: z.string(),
   iconOption: z.string().url().optional(),
   appLink: z.string().url().optional(),
-});
+})
 
 const TaskConfigSchema = z.object({
   name: z.string(),
   link: z.string().url(),
   iconOption: z.string().url(),
   actionPluginId: z.string(),
-});
+})
 
 const PluginConfigSchema = z.object({
   project: ProjectConfigSchema,
   tasks: z.array(TaskConfigSchema).nonempty(),
-});
+})
 
 async function validateConfigFile(filePath: string): Promise<void> {
   try {
-    const configFileContent = await fs.readFile(filePath, "utf8");
-    const config = yaml.load(configFileContent);
-    PluginConfigSchema.parse(config);
-    const { project, tasks } = config;
+    const configFileContent = await fs.readFile(filePath, 'utf8')
+    const config = yaml.load(configFileContent)
+    PluginConfigSchema.parse(config)
+    const { project, tasks } = config
 
     for (const task of tasks) {
       // validate each unique icon option url
       const uniqueIconOptions = new Set(
         [project.iconOption, task.iconOption].filter(Boolean),
-      );
+      )
       for (const iconOption of uniqueIconOptions) {
-        await validateIcon(iconOption);
+        await validateIcon(iconOption)
       }
     }
-    console.log(`Config in ${filePath} is valid.`);
+    console.log(`Config in ${filePath} is valid.`)
   } catch (error) {
-    console.error(`Error validating config in ${filePath}:`, error);
-    process.exit(1);
+    console.error(`Error validating config in ${filePath}:`, error)
+    process.exit(1)
   }
 }
 
@@ -57,28 +57,28 @@ async function validateIcon(iconUrl: string) {
         Authorization: `Bearer ${process.env.BOOST_API_TOKEN}`,
       },
     },
-  );
+  )
   if (response.status === 200) {
-    console.log("Icon is valid:", iconUrl);
+    console.log('Icon is valid:', iconUrl)
   } else {
-    throw new Error(`Icon validation failed for ${iconUrl}`);
+    throw new Error(`Icon validation failed for ${iconUrl}`)
   }
 }
 
 async function main() {
-  const newPackagesPaths = await utils.getNewPackages();
-  const updatedDetailsPaths = await utils.getUpdatedPluginDetailsPaths();
+  const newPackagesPaths = await utils.getNewPackages()
+  const updatedDetailsPaths = await utils.getUpdatedPluginDetailsPaths()
   const uniqueDetailsPaths = Array.from(
     new Set([...newPackagesPaths, ...updatedDetailsPaths]),
-  );
+  )
   if (uniqueDetailsPaths.length) {
-    const paths = await utils.validatePluginDetailsPaths(uniqueDetailsPaths);
+    const paths = await utils.validatePluginDetailsPaths(uniqueDetailsPaths)
     for (const path of paths) {
-      await validateConfigFile(path);
+      await validateConfigFile(path)
     }
   } else {
-    console.log("No new packages found.");
+    console.log('No new packages found.')
   }
 }
 
-main();
+main()

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -2,6 +2,8 @@ name: Pull request
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -13,43 +15,24 @@ jobs:
     uses: ./.github/workflows/verify.yml
     secrets: inherit
 
-  # bench:
-  #   if: false
-  #   name: Benchmark
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 5
+  verify-config-file-format:
+    name: Verify Config File Format
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-  #     - name: Install dependencies
-  #       uses: ./.github/actions/install-dependencies
+      - name: Fetch target branch
+        run: git fetch origin main:main
 
-  #     - name: Run benchmarks
-  #       run: pnpm bench:ci
-  #       env:
+      - name: Install dependencies
+        uses: ./.github/actions/install-dependencies
 
-  #     - name: Report benchmarks
-  #       run: pnpm bun ./.github/scripts/bench.ts
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # size:
-  #   name: Size
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 5
-
-  #   steps:
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-
-  #     - name: Install dependencies
-  #       uses: ./.github/actions/install-dependencies
-  #       env: 
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  #     - name: Report build size
-  #       uses: preactjs/compressed-size-action@v2
-  #       with:
-  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run config file format verification script
+        run: npx ts-node ./.github/scripts/verifyConfigFileFormat.ts
+        env:
+          BOOST_API: https://api.boost.xyz 
+          BOOST_API_TOKEN: ${{ secrets.BOOST_API_TOKEN }}

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -44,6 +44,39 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  register_new_plugins:
+    name: Register New Plugins
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        uses: ./.github/actions/install-dependencies
+
+      - name: Fetch target branch
+        run: git fetch origin
+
+      - name: Call API to register new plugin details without retry logic
+        run: |
+          for attempt in {1..3}; do
+            npx ts-node ./.github/scripts/registerNewPlugins.ts && break || {
+              echo "Attempt $attempt failed. Retrying in 5 seconds..."
+              sleep 5
+            }
+          done
+          if [ $attempt -eq 3 ]; then
+            echo "All attempts failed. Exiting..."
+            exit 1
+          fi
+        env:
+          STAGING_API_URL: https://api-staging.boost.xyz
+          PRODUCTION_API_URL: https://api.boost.xyz
+          BOOST_API_TOKEN: ${{ secrets.BOOST_API_TOKEN }}
+
   release:
     name: Release
     needs: verify

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -107,4 +107,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/apps/create-plugin/src/builder.ts
+++ b/apps/create-plugin/src/builder.ts
@@ -65,17 +65,20 @@ function registerHelpers() {
   Handlebars.registerHelper('eq', function (this: string, arg1, arg2, options) {
     return arg1 === arg2 ? options.fn(this) : options.inverse(this)
   })
-  Handlebars.registerHelper('hasAmountKey', function(this: string, tx, options) {
-    // Logic to determine if any tx.params keys start with "amount"
-    for (const transaction of tx) {
-      for (const key of Object.keys(transaction.params)) {
-        if (key.startsWith("amount")) {
-          return options.fn(this)
+  Handlebars.registerHelper(
+    'hasAmountKey',
+    function (this: string, tx, options) {
+      // Logic to determine if any tx.params keys start with "amount"
+      for (const transaction of tx) {
+        for (const key of Object.keys(transaction.params)) {
+          if (key.startsWith('amount')) {
+            return options.fn(this)
+          }
         }
       }
-    }
-    return options.inverse(this)
-  })
+      return options.inverse(this)
+    },
+  )
 }
 
 /**
@@ -175,6 +178,12 @@ async function replaceProjectName(params: BuilderParams) {
   const indexTemplate = Handlebars.compile(index)
   await fs.writeFile(indexPath, indexTemplate(params))
   console.log(`\t ${arrow} Updated file ${cyan('index.ts')}!`)
+
+  const configPath = path.join(dest, 'plugin-details.yml')
+  const config = await fs.readFile(configPath, 'utf8')
+  const configTemplate = Handlebars.compile(config)
+  await fs.writeFile(configPath, configTemplate(params))
+  console.log(`\t ${arrow} Updated file ${cyan('plugin-details.yml')}!`)
 }
 
 /**

--- a/apps/create-plugin/src/prompts.ts
+++ b/apps/create-plugin/src/prompts.ts
@@ -1,7 +1,12 @@
 import { Answers, PromptObject } from 'prompts'
 import { green, red } from 'picocolors'
 import { Address, type Hash, parseUnits } from 'viem'
-import { actionQuestions, mainQuestions, getTxHashQuestion } from './questions'
+import {
+  actionQuestions,
+  mainQuestions,
+  getTxHashQuestion,
+  detailsQuestions,
+} from './questions'
 import { ActionParamKeys, Actions } from './types'
 import { getTokenInfo, getTransaction } from './viem'
 import type {
@@ -21,7 +26,7 @@ export async function askQuestions() {
 
   while (addAnotherTransaction) {
     const { hash }: { hash: Hash | undefined } = await _prompts(
-      getTxHashQuestion(transactions)
+      getTxHashQuestion(transactions),
     )
 
     if (hash) {
@@ -78,12 +83,15 @@ export async function askQuestions() {
     addAnotherTransaction = addAnother
   }
 
+  const detailsResponse = await _prompts(detailsQuestions)
+
   return {
     projectName: response.name,
     chains: response.chain,
     tx: transactions,
     actionType: response.action,
     publish: response.publish,
+    details: detailsResponse,
   }
 }
 

--- a/apps/create-plugin/src/questions.ts
+++ b/apps/create-plugin/src/questions.ts
@@ -66,6 +66,57 @@ export const mainQuestions: PromptObject[] = [
   },
 ]
 
+export const detailsQuestions: PromptObject[] = [
+  {
+    type: 'text',
+    name: 'projectUrl',
+    message: 'What is the project url? (Optional)',
+    validate: (name: string) => {
+      if (
+        name !== '' &&
+        !/^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/.test(
+          name,
+        )
+      ) {
+        return 'Please enter a valid URL'
+      }
+      return true
+    },
+  },
+  {
+    type: 'text',
+    name: 'iconUrl',
+    message: 'What is the project icon url? (Optional)',
+    initial: '',
+    validate: (name: string) => {
+      if (
+        name !== '' &&
+        !/^(https?:\/\/.*\.(?:png|jpg|jpeg|svg)(\?.*)?)$/.test(name)
+      ) {
+        return 'Please enter a valid image URL'
+      }
+      return true
+    },
+  },
+  {
+    type: 'text',
+    name: 'taskUrl',
+    message:
+      'What is the action specfic url (ie: https://myProject/trade)? (Optional)',
+    validate: (name: string) => {
+      if (
+        name !== '' &&
+        !/^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/.test(
+          name,
+        )
+      ) {
+        return 'Please enter a valid URL'
+      }
+      return true
+    },
+  },
+]
+
 const descriptionQuestion: PromptObject = {
   type: 'text',
   name: 'description',
@@ -82,7 +133,9 @@ const descriptionQuestion: PromptObject = {
   },
 }
 
-export function getTxHashQuestion(transactions: TransactionDetail[]): PromptObject {
+export function getTxHashQuestion(
+  transactions: TransactionDetail[],
+): PromptObject {
   return {
     type: 'text',
     name: 'hash',

--- a/apps/create-plugin/src/viem.ts
+++ b/apps/create-plugin/src/viem.ts
@@ -101,7 +101,9 @@ export async function getTokenInfo(address: Address, chain: number) {
       return { decimals, symbol }
     } catch {
       console.log(
-        yellow(`decimals for token ${address} not found... using default decimal value 18`),
+        yellow(
+          `decimals for token ${address} not found... using default decimal value 18`,
+        ),
       )
       return { decimals: 18 }
     }

--- a/apps/create-plugin/template/plugin-details.yml
+++ b/apps/create-plugin/template/plugin-details.yml
@@ -1,0 +1,12 @@
+project:
+  name: {{capitalize projectName}}
+  iconOption: {{{details.iconUrl}}}
+  appLink: {{{details.projectUrl}}}
+  
+tasks:
+    # action specific name, this is what will show as the default title for your boosts
+  - name: {{capitalize actionType}} on {{capitalize projectName}}
+    # action specific link to your project. (ie: myapp.com/{{lowercase actionType}})
+    link: {{#if details.taskUrl}}{{{details.taskUrl}}}{{else}}{{{details.projectUrl}}}{{/if}}
+    iconOption: {{{details.iconUrl}}}
+    actionPluginId: {{lowercase actionType}}

--- a/apps/create-plugin/template/src/test-transactions.ts.t
+++ b/apps/create-plugin/template/src/test-transactions.ts.t
@@ -8,8 +8,8 @@ import { type {{capitalize actionType}}ActionParams } from '@rabbitholegg/questd
 {{/hasAmountKey}}
 import {
   createTestCase,
-  type TestParams,{{#eq actionType 'bridge'}}
-  Chains{{/eq}}
+  type TestParams,{{#eq actionType 'bridge'}}{{#if tx.length}}
+  Chains{{/if}}{{/eq}}
 } from '@rabbitholegg/questdk-plugin-utils'
 
 {{#unless tx.length}}
@@ -29,12 +29,12 @@ export const {{uppercase actionType}}_TEST: TestParams<{{capitalize actionType}}
     destinationChainId: 0,
   {{else}}
   {{#eq actionType 'mint'}}
-    tokenId: '0',
-    amount: '0',
+    chainId: 0,
+    contractAddress: '0x0',
   {{else}}
   {{#eq actionType 'burn'}}
-    tokenId: '0',
-    amount: '0',
+    chainId: 0,
+    contractAddress: '0x0',
   {{else}}
   {{#eq actionType 'delegate'}}
     chainId: 0,


### PR DESCRIPTION
Details
------
- Introduces a `plugin-details.yml` file in the template. 
- Builder will ask for app and icon url during the setup process for a new plugin. This is optional and these details can be filled in afterwards.
- When the github actions are triggered, they check to see if a new package (plugin) is present, and verifies that it has a valid `plugin-details.yml` file. If a new package is detected and there is no config, or the config is not valid, the action will fail.
- When the pr is merged to main, an action will run to send the details from the `plugin-details.yml` to the staging and production api. The details will already be validated at this point.

[Backend Changes](https://github.com/rabbitholegg/rh/pull/2405)

------
Issues
-----

- In the scripts, there is some namespace conflicts wherever trying to use a variable that is declared in another script file. I got around this by prefixing any reused variable name with an underscore, but I feel this should not be happening.

![CleanShot 2024-03-02 at 13 05 29@2x](https://github.com/rabbitholegg/questdk-plugins/assets/62824345/19b07cad-5e27-4087-bb48-89bd7203142a)

- ~~When updating the config file with a new image url, it wont change the image on the S3 bucket unless you use a different name.~~ Image updates do work, the old image is just cached for a while. 😀

------
Testing
------

I have done **a lot** of testing locally.

**Passes**
  - [x] when all details are valid in new plugin config file
  - [x] when all details are valid on updated config file
  - [x] when all details are valid, adding a new config file to existing package
  - [x] when making non-config related changes (passes with "no changes found")
  - [x] when multiple valid tasks are provided

**Fails**
  - [x] when mandatory details are missing
  - [x] when image is too big
  - [x] when image url is not an image
  - [x] when icon or applink is not a url
  - [x] when a new package is detected and no config file is found
  - [x] when adding an invalid config file to an existing package
  - [x] when updated an existing config file using invalid details

