### PR TITLE
getFees - break fees up into action and project

### DIFF
--- a/.changeset/nine-steaks-clap.md
+++ b/.changeset/nine-steaks-clap.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-zora": patch
+---
+
+Zora getFees incorrect fees

--- a/packages/zora/src/Zora.ts
+++ b/packages/zora/src/Zora.ts
@@ -232,7 +232,7 @@ export const getFees = async (
       typeof amount === 'number' ? BigInt(amount) : BigInt(1)
     const fee = await getMintCosts({ salesConfigAndTokenInfo, quantityToMint })
 
-    return { actionFee: fee.mintFee, projectFee: fee.tokenPurchaseCost }
+    return { actionFee: fee.tokenPurchaseCost, projectFee: fee.mintFee}
   } catch (err) {
     console.error(err)
     return { actionFee: parseEther('0'), projectFee: parseEther('0.000777') } // https://github.com/ourzora/zora-protocol/blob/e9fb5072112b4434cc649c95729f4bd8c6d5e0d0/packages/protocol-sdk/src/apis/chain-constants.ts#L27


### PR DESCRIPTION
previously Sound, Mirror, and Zora were only returning the total fees associated with a project
now, we break up fees into an object { projectFees: BigInt, actionFees: BigInt } in a non-destructive way to ensure backwards compatibility
tests written to match pattern for getProjectFees
documentation added where needed (referenced Soundxyz sdk)