### PR TITLE
Mmackz/fix_zora_simulate

### DIFF
--- a/packages/zora/src/Zora.test.ts
+++ b/packages/zora/src/Zora.test.ts
@@ -286,14 +286,14 @@ describe('Given the getFee function', () => {
 describe('simulateMint function', () => {
   test('should simulate a 1155 mint when tokenId is not 0', async () => {
     const mint: MintIntentParams = {
-      chainId: Chains.ZORA,
-      contractAddress: '0xc53c050131a3507d51d014445f666f4c3a1a2c24',
-      tokenId: 1, // not 0
+      chainId: Chains.BASE,
+      contractAddress: '0x5F69dA5Da41E5472AfB88fc291e7a92b7F15FbC5',
+      tokenId: 10,
       amount: BigInt(1),
-      recipient: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+      recipient: '0xf70da97812CB96acDF810712Aa562db8dfA3dbEF',
     }
     const value = parseEther('0.000777')
-    const account = '0xE4eDb277e41dc89aB076a1F049f4a3EfA700bCE8'
+    const account = '0xf70da97812CB96acDF810712Aa562db8dfA3dbEF'
 
     const result = await simulateMint(mint, value, account)
     const request = result.request

--- a/packages/zora/src/Zora.ts
+++ b/packages/zora/src/Zora.ts
@@ -111,7 +111,6 @@ export const getMintIntent = async (
   let fixedPriceSaleStratAddress = FIXED_PRICE_SALE_STRATS[chainId]
 
   try {
-    console.log({ chainId, contractAddress, tokenId })
     fixedPriceSaleStratAddress = (
       await getSalesConfigAndTokenInfo(chainId, contractAddress, tokenId)
     ).fixedPrice.address


### PR DESCRIPTION
The NFT used for the `simulateMint` function has a time-limited mint which will expire next week. After this mint expires, the simulations will fail.

This pr replaces the current test with one that uses an NFT that will remain open indefinately.