### PR TITLE
feat(sound): add support for legacy contract in simulations

### DIFF
--- a/.changeset/soft-cougars-love.md
+++ b/.changeset/soft-cougars-love.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-soundxyz": minor
+---
+
+add support for legacy contract in simulation and projectfees helpers

--- a/packages/soundxyz/src/Soundxyz.test.ts
+++ b/packages/soundxyz/src/Soundxyz.test.ts
@@ -170,7 +170,7 @@ describe('getFees', () => {
 })
 
 describe('simulateMint function', () => {
-    test('should simulate a mint', async () => {
+  test('should simulate a mint', async () => {
     const mint: MintIntentParams = {
       chainId: Chains.OPTIMISM,
       contractAddress: '0xdf71F2F15bCcDC7c7A89F01dd45cDE5A43F7e79f',

--- a/packages/soundxyz/src/Soundxyz.test.ts
+++ b/packages/soundxyz/src/Soundxyz.test.ts
@@ -1,25 +1,25 @@
-import { apply } from '@rabbitholegg/questdk'
-import { describe, expect, test, vi } from 'vitest'
 import {
   getDynamicNameParams,
   getProjectFees,
   mint,
   simulateMint,
 } from './Soundxyz'
+import { SUPERMINTER, SUPERMINTER_V2, SUPERMINTER_V2_ABI } from './constants'
 import {
-  passingTestCases,
-  failingTestCases,
   OP_SUPERMINTER_V2,
+  failingTestCases,
+  passingTestCases,
 } from './test-transactions'
 import { Chains } from './utils'
-import { SUPERMINTER, SUPERMINTER_V2, SUPERMINTER_V2_ABI } from './constants'
-import { type Address, parseEther } from 'viem'
+import { apply } from '@rabbitholegg/questdk'
 import {
   ActionType,
   type DisctriminatedActionParams,
   type MintActionParams,
   type MintIntentParams,
 } from '@rabbitholegg/questdk-plugin-utils'
+import { type Address, parseEther } from 'viem'
+import { describe, expect, test, vi } from 'vitest'
 
 describe('Given the soundxyz plugin', () => {
   describe('When handling the mint action', () => {

--- a/packages/soundxyz/src/Soundxyz.test.ts
+++ b/packages/soundxyz/src/Soundxyz.test.ts
@@ -138,6 +138,15 @@ describe('getProjectFees', () => {
     expect(getProjectFeesSpy).toHaveBeenCalledWith(mintParams)
     expect(fee).toEqual(BigInt('777000000000000'))
   })
+
+  test('should return the correct fee for a legacy mint', async () => {
+    const contractAddress: Address =
+      '0x0c418874315698096ecA7ce0e1Dccf0A517DC9DE'
+    const mintParams = { contractAddress, chainId: Chains.OPTIMISM }
+
+    const fee = await getProjectFees(mintParams)
+    expect(fee).equals(777000000000000n)
+  })
 })
 describe('getFees', () => {
   test('should return the correct fee for project and action', async () => {
@@ -157,39 +166,6 @@ describe('getFees', () => {
     expect(getProjectFeesSpy).toHaveBeenCalledWith(mintParams)
     expect(fee.projectFee).toEqual(BigInt('777000000000000'))
     expect(fee.actionFee).toEqual(BigInt('0'))
-  })
-})
-
-describe('Given the getProjectFee function', () => {
-  test('should return the correct fee for a legacy mint', async () => {
-    const contractAddress: Address =
-      '0x0c418874315698096ecA7ce0e1Dccf0A517DC9DE'
-    const mintParams = { contractAddress, chainId: Chains.OPTIMISM }
-
-    const fee = await getProjectFees(mintParams)
-    expect(fee).equals(777000000000000n)
-  })
-
-  test('should return the correct fee for an 1155 mint', async () => {
-    const contractAddress: Address =
-      '0x393c46fe7887697124a73f6028f39751aa1961a3'
-    const tokenId = 1
-    const mintParams = {
-      contractAddress,
-      tokenId,
-      chainId: Chains.ZORA,
-      amount: 2,
-    }
-
-    const mockFns = {
-      getProjectFees: async (_mint: MintActionParams) =>
-        BigInt('1554000000000000'),
-    }
-
-    const getProjectsFeeSpy = vi.spyOn(mockFns, 'getProjectFees')
-    const fee = await mockFns.getProjectFees(mintParams)
-    expect(getProjectsFeeSpy.mock.calls.length).toBe(1)
-    expect(fee).equals(BigInt('1554000000000000'))
   })
 })
 

--- a/packages/soundxyz/src/Soundxyz.test.ts
+++ b/packages/soundxyz/src/Soundxyz.test.ts
@@ -170,6 +170,22 @@ describe('getFees', () => {
 })
 
 describe('simulateMint function', () => {
+    test('should simulate a mint', async () => {
+    const mint: MintIntentParams = {
+      chainId: Chains.OPTIMISM,
+      contractAddress: '0xdf71F2F15bCcDC7c7A89F01dd45cDE5A43F7e79f',
+      amount: BigInt(1),
+      recipient: '0xf70da97812CB96acDF810712Aa562db8dfA3dbEF',
+    }
+    const value = parseEther('0.000777')
+    const account = '0xf70da97812CB96acDF810712Aa562db8dfA3dbEF'
+
+    const result = await simulateMint(mint, value, account)
+    const request = result.request
+    expect(request.address).toBe(SUPERMINTER_V2)
+    expect(request.value).toBe(value)
+  })
+
   test('should simulate a legacy mint', async () => {
     const mint: MintIntentParams = {
       chainId: Chains.OPTIMISM,

--- a/packages/soundxyz/src/Soundxyz.ts
+++ b/packages/soundxyz/src/Soundxyz.ts
@@ -204,12 +204,7 @@ export const getFees = async (
       address: SUPERMINTER,
       abi: TOTAL_PRICE_AND_FEES_V1_ABI,
       functionName: 'totalPriceAndFees',
-      args: [
-        contractAddress,
-        tier,
-        BigInt(0),
-        quantity,
-      ],
+      args: [contractAddress, tier, BigInt(0), quantity],
     })) as TotalPriceAndFees
 
     return {

--- a/packages/soundxyz/src/Soundxyz.ts
+++ b/packages/soundxyz/src/Soundxyz.ts
@@ -1,38 +1,38 @@
 import {
-  type TransactionFilter,
-  type MintActionParams,
-  compressJson,
-} from '@rabbitholegg/questdk'
-import {
-  createPublicClient,
-  http,
-  encodeFunctionData,
-  type Address,
-  type TransactionRequest,
-  zeroAddress,
-  zeroHash,
-  type PublicClient,
-  type SimulateContractReturnType,
-} from 'viem'
-import {
-  type MintIntentParams,
-  chainIdToViemChain,
-  DEFAULT_ACCOUNT,
-  type DisctriminatedActionParams,
-  ActionType,
-} from '@rabbitholegg/questdk-plugin-utils'
-import {
-  NEXT_SCHEDULE_NUM_ABI,
   MINT_INFO_LIST_ABI,
+  NEXT_SCHEDULE_NUM_ABI,
   SUPERMINTER,
-  SUPERMINTER_V2,
   SUPERMINTER_V1_ABI,
+  SUPERMINTER_V2,
   SUPERMINTER_V2_ABI,
   TOTAL_PRICE_AND_FEES_V1_ABI,
   TOTAL_PRICE_AND_FEES_V2_ABI,
 } from './constants'
-import { Chains } from './utils'
 import type { TotalPriceAndFees } from './types'
+import { Chains } from './utils'
+import {
+  type MintActionParams,
+  type TransactionFilter,
+  compressJson,
+} from '@rabbitholegg/questdk'
+import {
+  ActionType,
+  DEFAULT_ACCOUNT,
+  type DisctriminatedActionParams,
+  type MintIntentParams,
+  chainIdToViemChain,
+} from '@rabbitholegg/questdk-plugin-utils'
+import {
+  type Address,
+  type PublicClient,
+  type SimulateContractReturnType,
+  type TransactionRequest,
+  createPublicClient,
+  encodeFunctionData,
+  http,
+  zeroAddress,
+  zeroHash,
+} from 'viem'
 
 export const mint = async (
   mint: MintActionParams,

--- a/packages/soundxyz/src/constants.ts
+++ b/packages/soundxyz/src/constants.ts
@@ -45,6 +45,22 @@ export const SUPERMINTER_V1_ABI = [
     stateMutability: 'payable',
     type: 'function',
   },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'paid',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'required',
+        type: 'uint256',
+      },
+    ],
+    name: 'WrongPayment',
+    type: 'error',
+  },
 ]
 
 export const SUPERMINTER_V2_ABI = [
@@ -250,6 +266,50 @@ export const TOTAL_PRICE_AND_FEES_V2_ABI = [
         internalType: 'struct ISuperMinterV2.TotalPriceAndFees',
         name: '',
         type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+]
+
+export const MINT_INFO_LIST_ABI = [
+  {
+    inputs: [{ internalType: 'address', name: 'edition', type: 'address' }],
+    name: 'mintInfoList',
+    outputs: [
+      {
+        components: [
+          { internalType: 'address', name: 'edition', type: 'address' },
+          { internalType: 'uint8', name: 'tier', type: 'uint8' },
+          { internalType: 'uint8', name: 'scheduleNum', type: 'uint8' },
+          { internalType: 'address', name: 'platform', type: 'address' },
+          { internalType: 'uint96', name: 'price', type: 'uint96' },
+          { internalType: 'uint32', name: 'startTime', type: 'uint32' },
+          { internalType: 'uint32', name: 'endTime', type: 'uint32' },
+          {
+            internalType: 'uint32',
+            name: 'maxMintablePerAccount',
+            type: 'uint32',
+          },
+          { internalType: 'uint32', name: 'maxMintable', type: 'uint32' },
+          { internalType: 'uint32', name: 'minted', type: 'uint32' },
+          { internalType: 'uint16', name: 'affiliateFeeBPS', type: 'uint16' },
+          { internalType: 'uint8', name: 'mode', type: 'uint8' },
+          { internalType: 'bool', name: 'paused', type: 'bool' },
+          { internalType: 'bool', name: 'hasMints', type: 'bool' },
+          {
+            internalType: 'bytes32',
+            name: 'affiliateMerkleRoot',
+            type: 'bytes32',
+          },
+          { internalType: 'bytes32', name: 'merkleRoot', type: 'bytes32' },
+          { internalType: 'address', name: 'signer', type: 'address' },
+          { internalType: 'bool', name: 'usePlatformSigner', type: 'bool' },
+        ],
+        internalType: 'struct ISuperMinter.MintInfo[]',
+        name: 'a',
+        type: 'tuple[]',
       },
     ],
     stateMutability: 'view',

--- a/packages/soundxyz/src/constants.ts
+++ b/packages/soundxyz/src/constants.ts
@@ -1,6 +1,53 @@
 export const SUPERMINTER = '0x0000000000CF4558c36229ac0026ee16D3aE35Cd'
 export const SUPERMINTER_V2 = '0x000000000001A36777f9930aAEFf623771b13e70'
-export const SUPERMINTER_ABI = [
+
+export const SUPERMINTER_V1_ABI = [
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: 'address', name: 'edition', type: 'address' },
+          { internalType: 'uint8', name: 'tier', type: 'uint8' },
+          { internalType: 'uint8', name: 'scheduleNum', type: 'uint8' },
+          { internalType: 'address', name: 'to', type: 'address' },
+          { internalType: 'uint32', name: 'quantity', type: 'uint32' },
+          { internalType: 'address', name: 'allowlisted', type: 'address' },
+          {
+            internalType: 'uint32',
+            name: 'allowlistedQuantity',
+            type: 'uint32',
+          },
+          {
+            internalType: 'bytes32[]',
+            name: 'allowlistProof',
+            type: 'bytes32[]',
+          },
+          { internalType: 'uint96', name: 'signedPrice', type: 'uint96' },
+          { internalType: 'uint32', name: 'signedQuantity', type: 'uint32' },
+          { internalType: 'uint32', name: 'signedClaimTicket', type: 'uint32' },
+          { internalType: 'uint32', name: 'signedDeadline', type: 'uint32' },
+          { internalType: 'bytes', name: 'signature', type: 'bytes' },
+          { internalType: 'address', name: 'affiliate', type: 'address' },
+          {
+            internalType: 'bytes32[]',
+            name: 'affiliateProof',
+            type: 'bytes32[]',
+          },
+          { internalType: 'uint256', name: 'attributionId', type: 'uint256' },
+        ],
+        internalType: 'struct ISuperMinter.MintTo',
+        name: 'p',
+        type: 'tuple',
+      },
+    ],
+    name: 'mintTo',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+]
+
+export const SUPERMINTER_V2_ABI = [
   {
     inputs: [
       {
@@ -67,129 +114,53 @@ export const SUPERMINTER_ABI = [
 export const NEXT_SCHEDULE_NUM_ABI = [
   {
     inputs: [
-      {
-        internalType: 'address',
-        name: 'edition',
-        type: 'address',
-      },
-      {
-        internalType: 'uint8',
-        name: 'tier',
-        type: 'uint8',
-      },
+      { internalType: 'address', name: 'edition', type: 'address' },
+      { internalType: 'uint8', name: 'tier', type: 'uint8' },
     ],
     name: 'nextScheduleNum',
-    outputs: [
-      {
-        internalType: 'uint8',
-        name: '',
-        type: 'uint8',
-      },
-    ],
+    outputs: [{ internalType: 'uint8', name: '', type: 'uint8' }],
     stateMutability: 'view',
     type: 'function',
   },
+]
+
+export const TOTAL_PRICE_AND_FEES_V1_ABI = [
   {
     inputs: [
-      {
-        internalType: 'address',
-        name: 'edition',
-        type: 'address',
-      },
+      { internalType: 'address', name: 'edition', type: 'address' },
+      { internalType: 'uint8', name: 'tier', type: 'uint8' },
+      { internalType: 'uint8', name: 'scheduleNum', type: 'uint8' },
+      { internalType: 'uint32', name: 'quantity', type: 'uint32' },
     ],
-    name: 'mintInfoList',
+    name: 'totalPriceAndFees',
     outputs: [
       {
         components: [
+          { internalType: 'uint256', name: 'total', type: 'uint256' },
+          { internalType: 'uint256', name: 'subTotal', type: 'uint256' },
+          { internalType: 'uint256', name: 'unitPrice', type: 'uint256' },
+          { internalType: 'uint256', name: 'platformFee', type: 'uint256' },
+          { internalType: 'uint256', name: 'platformFlatFee', type: 'uint256' },
           {
-            internalType: 'address',
-            name: 'edition',
-            type: 'address',
+            internalType: 'uint256',
+            name: 'platformTxFlatFee',
+            type: 'uint256',
           },
           {
-            internalType: 'uint8',
-            name: 'tier',
-            type: 'uint8',
+            internalType: 'uint256',
+            name: 'platformMintFlatFee',
+            type: 'uint256',
           },
           {
-            internalType: 'uint8',
-            name: 'scheduleNum',
-            type: 'uint8',
+            internalType: 'uint256',
+            name: 'platformMintBPSFee',
+            type: 'uint256',
           },
-          {
-            internalType: 'address',
-            name: 'platform',
-            type: 'address',
-          },
-          {
-            internalType: 'uint96',
-            name: 'price',
-            type: 'uint96',
-          },
-          {
-            internalType: 'uint32',
-            name: 'startTime',
-            type: 'uint32',
-          },
-          {
-            internalType: 'uint32',
-            name: 'endTime',
-            type: 'uint32',
-          },
-          {
-            internalType: 'uint32',
-            name: 'maxMintablePerAccount',
-            type: 'uint32',
-          },
-          {
-            internalType: 'uint32',
-            name: 'maxMintable',
-            type: 'uint32',
-          },
-          {
-            internalType: 'uint32',
-            name: 'minted',
-            type: 'uint32',
-          },
-          {
-            internalType: 'uint16',
-            name: 'affiliateFeeBPS',
-            type: 'uint16',
-          },
-          {
-            internalType: 'uint8',
-            name: 'mode',
-            type: 'uint8',
-          },
-          {
-            internalType: 'bool',
-            name: 'paused',
-            type: 'bool',
-          },
-          {
-            internalType: 'bool',
-            name: 'hasMints',
-            type: 'bool',
-          },
-          {
-            internalType: 'bytes32',
-            name: 'affiliateMerkleRoot',
-            type: 'bytes32',
-          },
-          {
-            internalType: 'bytes32',
-            name: 'merkleRoot',
-            type: 'bytes32',
-          },
-          {
-            internalType: 'address',
-            name: 'signer',
-            type: 'address',
-          },
+          { internalType: 'uint256', name: 'affiliateFee', type: 'uint256' },
         ],
-        internalType: 'struct ISuperMinterV2.MintInfo[]',
-        name: 'a',
-        type: 'tuple[]',
+        internalType: 'struct ISuperMinter.TotalPriceAndFees',
+        name: '',
+        type: 'tuple',
       },
     ],
     stateMutability: 'view',
@@ -197,7 +168,7 @@ export const NEXT_SCHEDULE_NUM_ABI = [
   },
 ]
 
-export const TOTAL_PRICE_AND_FEES_ABI = [
+export const TOTAL_PRICE_AND_FEES_V2_ABI = [
   {
     inputs: [],
     name: 'ExceedsMaxPerAccount',

--- a/packages/soundxyz/src/index.ts
+++ b/packages/soundxyz/src/index.ts
@@ -1,19 +1,19 @@
 import {
-  type IActionPlugin,
-  PluginActionNotImplementedError,
   type ActionParams,
+  type IActionPlugin,
   type MintActionParams,
+  PluginActionNotImplementedError,
 } from '@rabbitholegg/questdk-plugin-utils'
 
 import {
-  mint,
-  getSupportedChainIds,
-  getSupportedTokenAddresses,
   getDynamicNameParams,
+  getFees,
   getMintIntent,
   getProjectFees,
+  getSupportedChainIds,
+  getSupportedTokenAddresses,
+  mint,
   simulateMint,
-  getFees,
 } from './Soundxyz.js'
 
 export const Soundxyz: IActionPlugin = {

--- a/packages/soundxyz/src/test-transactions.ts
+++ b/packages/soundxyz/src/test-transactions.ts
@@ -1,8 +1,8 @@
+import { Chains, type TestParams, createTestCase } from './utils'
 import {
   GreaterThanOrEqual,
   type MintActionParams,
 } from '@rabbitholegg/questdk'
-import { Chains, createTestCase, type TestParams } from './utils'
 
 const OP_SUPERMINTER: TestParams<MintActionParams> = {
   transaction: {


### PR DESCRIPTION
This PR adds support for the legacy `SUPERMINTER` contract to pass simulations and calculate fees.

![CleanShot 2024-03-28 at 17 25 14@2x](https://github.com/rabbitholegg/questdk-plugins/assets/62824345/d74e1362-3398-41d0-a2b6-d81605bef4d7)
