### PR TITLE
feat(builder): add blast chain support for builder

### DIFF
--- a/.changeset/clean-coins-count.md
+++ b/.changeset/clean-coins-count.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/create-plugin": minor
+---
+
+add blast chain support

--- a/apps/create-plugin/src/viem.ts
+++ b/apps/create-plugin/src/viem.ts
@@ -1,18 +1,19 @@
 import {
-  createPublicClient,
-  http,
-  type Hash,
-  type PublicClient,
   type Address,
   type Chain,
-  zeroAddress,
+  type Hash,
+  type PublicClient,
+  createPublicClient,
+  http,
   isAddress,
+  zeroAddress,
 } from 'viem'
 import {
-  mainnet,
-  base,
-  optimism,
   arbitrum,
+  base,
+  blast,
+  mainnet,
+  optimism,
   polygon,
   zkSync,
   zora,
@@ -31,10 +32,11 @@ interface Transaction {
 const chains: Record<number, Chain> = {
   1: mainnet,
   10: optimism,
-  42161: arbitrum,
-  8453: base,
   137: polygon,
   324: zkSync,
+  8453: base,
+  42161: arbitrum,
+  81457: blast,
   7777777: zora,
 }
 

--- a/apps/create-plugin/src/viem.ts
+++ b/apps/create-plugin/src/viem.ts
@@ -1,3 +1,4 @@
+import { Chains } from '@rabbitholegg/questdk-plugin-utils'
 import {
   type Address,
   type Chain,
@@ -30,14 +31,14 @@ interface Transaction {
 }
 
 const chains: Record<number, Chain> = {
-  1: mainnet,
-  10: optimism,
-  137: polygon,
-  324: zkSync,
-  8453: base,
-  42161: arbitrum,
-  81457: blast,
-  7777777: zora,
+  [Chains.ETHEREUM]: mainnet,
+  [Chains.OPTIMISM]: optimism,
+  [Chains.POLYGON_POS]: polygon,
+  [Chains.ZK_SYNC_ERA]: zkSync,
+  [Chains.BASE]: base,
+  [Chains.ARBITRUM_ONE]: arbitrum,
+  [Chains.BLAST]: blast,
+  [Chains.ZORA]: zora,
 }
 
 function getClient(chain: Chain): PublicClient {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@rabbitholegg/questdk": "2.0.0-alpha.35",
-    "viem": "2.7.9",
+    "viem": "2.9.9",
     "axios": "1.5.0",
     "zod": "3.21.4",
     "react-intl": "6.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: 5.0.1
         version: 5.0.1
       viem:
-        specifier: 2.7.9
-        version: 2.7.9(typescript@5.3.2)(zod@3.21.4)
+        specifier: 2.9.9
+        version: 2.9.9(typescript@5.3.2)(zod@3.21.4)
       zod:
         specifier: 3.21.4
         version: 3.21.4
@@ -11822,6 +11822,29 @@ packages:
 
   /viem@2.7.9(typescript@5.3.2)(zod@3.21.4):
     resolution: {integrity: sha512-iDfc8TwaZFp1K95zlsxYh6Cs0OWCt35Tqs8uYgXKSxtz7w075mZ0H5SJ8zSyJGoEaticVDhtdmRRX6TtcW9EeQ==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.0
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@scure/bip32': 1.3.2
+      '@scure/bip39': 1.2.1
+      abitype: 1.0.0(typescript@5.3.2)(zod@3.21.4)
+      isows: 1.0.3(ws@8.13.0)
+      typescript: 5.3.2
+      ws: 8.13.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+    dev: false
+
+  /viem@2.9.9(typescript@5.3.2)(zod@3.21.4):
+    resolution: {integrity: sha512-SUIHBL6M5IIlqDCMEQwAAvHzeglaM4FEqM6bCI+srLXtFYmrpV4tWhnpobQRNwh4f7HIksmKLLZ+cytv8FfnJQ==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:


### PR DESCRIPTION
- bumps viem version (2.7.9 -> 2.9.9)

- add blast chain to builders viem client. This allows it to look up transaction hashes on blast network.

- use Chains enum