### PR TITLE
fix(superbridge): fix issue with invalid transactions passing

### DIFF
--- a/.changeset/nervous-keys-design.md
+++ b/.changeset/nervous-keys-design.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-superbridge": minor
+---
+
+fix issue with invalid transactions passing

--- a/packages/superbridge/src/test-transactions.ts
+++ b/packages/superbridge/src/test-transactions.ts
@@ -310,4 +310,10 @@ export const failingTestCases = [
   createTestCase(WITHDRAW_TO, 'when recipient is not correct', {
     recipient: '0x04d1963c76eb1bec59d0eeb249ed86f736b82993',
   }),
+  createTestCase(BRIDGE_ETH_TO, 'when bridging BLU from ETH -> BASE', {
+    amount: GreaterThanOrEqual(parseUnits('100', 18)),
+    tokenAddress: '0xfe3b138879d6d0555be4132dcfe6e7424e257a2e',
+    sourceChainId: 1,
+    destinationChainId: 8453,
+  }),
 ]


### PR DESCRIPTION
- Fixes an issue where bridging ETH was able to pass a boost for a specific token.

It now removes any ETH based input filters if tokenAddress is an ERC20.

![CleanShot 2024-05-17 at 12 00 33@2x](https://github.com/rabbitholegg/questdk-plugins/assets/62824345/071867dd-69c0-4c65-b814-e2f7f7c1823d)

https://linear.app/rh-app/issue/BOOST-4002/possible-bug-in-superbridge-plugin