### PR TITLE
chore: increase timeout for release step to 20 minutes

### DIFF
--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -48,7 +48,7 @@ jobs:
     name: Release
     needs: verify
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
- temporary fix for consistently hitting timeouts on release step