### PR TITLE
Enable State Override

### DIFF
--- a/.changeset/serious-tips-grow.md
+++ b/.changeset/serious-tips-grow.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-zora": patch
+---
+
+enable state override for balance

--- a/packages/zora/src/Zora.ts
+++ b/packages/zora/src/Zora.ts
@@ -100,9 +100,9 @@ export const mint = async (
 
   const mintContracts = universalMinter
     ? ([
-      contractAddress.toLowerCase(),
-      universalMinter.toLowerCase(),
-    ] as Address[])
+        contractAddress.toLowerCase(),
+        universalMinter.toLowerCase(),
+      ] as Address[])
     : contractAddress
 
   const andArray721 = []
@@ -294,10 +294,12 @@ export const simulateMint = async (
       functionName: 'mint',
       args: mintArgs,
       account: from,
-      stateOverride: [{
-        address: from,
-        balance: parseEther('100'),
-      }],
+      stateOverride: [
+        {
+          address: from,
+          balance: parseEther('100'),
+        },
+      ],
     })
     return result
   } catch {
@@ -315,10 +317,12 @@ export const simulateMint = async (
         functionName: 'mint',
         args: mintArgs,
         account: from,
-        stateOverride: [{
-          address: from,
-          balance: parseEther('100'),
-        }],
+        stateOverride: [
+          {
+            address: from,
+            balance: parseEther('100'),
+          },
+        ],
       })
       return result
     } catch {
@@ -330,10 +334,12 @@ export const simulateMint = async (
         functionName: 'purchase',
         args: [amount],
         account: from,
-        stateOverride: [{
-          address: from,
-          balance: parseEther('100'),
-        }],
+        stateOverride: [
+          {
+            address: from,
+            balance: parseEther('100'),
+          },
+        ],
       })
       return result
     }

--- a/packages/zora/src/Zora.ts
+++ b/packages/zora/src/Zora.ts
@@ -100,9 +100,9 @@ export const mint = async (
 
   const mintContracts = universalMinter
     ? ([
-        contractAddress.toLowerCase(),
-        universalMinter.toLowerCase(),
-      ] as Address[])
+      contractAddress.toLowerCase(),
+      universalMinter.toLowerCase(),
+    ] as Address[])
     : contractAddress
 
   const andArray721 = []

--- a/packages/zora/src/Zora.ts
+++ b/packages/zora/src/Zora.ts
@@ -294,6 +294,10 @@ export const simulateMint = async (
       functionName: 'mint',
       args: mintArgs,
       account: from,
+      stateOverride: [{
+        address: from,
+        balance: parseEther('100'),
+      }],
     })
     return result
   } catch {
@@ -311,11 +315,10 @@ export const simulateMint = async (
         functionName: 'mint',
         args: mintArgs,
         account: from,
-        // TODO: There's a bug in Viem preventing this behavior; log issue with them
-        // stateOverride: [{
-        //   address: from,
-        //   balance: BigInt("0x56bc75e2d63100000")
-        // }],
+        stateOverride: [{
+          address: from,
+          balance: parseEther('100'),
+        }],
       })
       return result
     } catch {
@@ -327,6 +330,10 @@ export const simulateMint = async (
         functionName: 'purchase',
         args: [amount],
         account: from,
+        stateOverride: [{
+          address: from,
+          balance: parseEther('100'),
+        }],
       })
       return result
     }


### PR DESCRIPTION
Increases the balance when running `simulateContract` to prevent the low balance `ContractFunctionExecutionError`

```
ContractFunctionExecutionError: The total cost (gas * gas fee + value) of executing this transaction exceeds the balance of the account.
```