### PR TITLE
feat(boost): add support for Boost `complete` plugin 

### DIFF
--- a/.changeset/silver-olives-pretend.md
+++ b/.changeset/silver-olives-pretend.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-boost": minor
+---
+
+add complete action to boost plugin

--- a/packages/boost/rollup.config.mjs
+++ b/packages/boost/rollup.config.mjs
@@ -1,8 +1,8 @@
 import babel from '@rollup/plugin-babel'
-import resolve from '@rollup/plugin-node-resolve'
-import terser from '@rollup/plugin-terser'
 import commonjs from '@rollup/plugin-commonjs'
 import json from '@rollup/plugin-json'
+import resolve from '@rollup/plugin-node-resolve'
+import terser from '@rollup/plugin-terser'
 import polyfillNode from 'rollup-plugin-polyfill-node'
 
 const extensions = ['.js', '.ts']

--- a/packages/boost/src/Boost.test.ts
+++ b/packages/boost/src/Boost.test.ts
@@ -1,14 +1,14 @@
-import { apply } from '@rabbitholegg/questdk'
-import { describe, expect, test } from 'vitest'
+import { complete, mint } from './Boost'
+import { BOOST_PASS_ABI } from './constants'
 import {
+  BOOST_PASS_MINT,
   failingTestCasesComplete,
   failingTestCasesMint,
   passingTestCasesComplete,
   passingTestCasesMint,
-  BOOST_PASS_MINT,
 } from './test-transactions'
-import { complete, mint } from './Boost'
-import { BOOST_PASS_ABI } from './constants'
+import { apply } from '@rabbitholegg/questdk'
+import { describe, expect, test } from 'vitest'
 
 describe('Given the boost plugin', () => {
   describe('When handling the mint action', () => {

--- a/packages/boost/src/Boost.ts
+++ b/packages/boost/src/Boost.ts
@@ -1,6 +1,7 @@
 import {
   type TransactionFilter,
   type MintActionParams,
+  type CompleteActionParams,
   compressJson,
 } from '@rabbitholegg/questdk'
 import { Chains } from '@rabbitholegg/questdk-plugin-utils'
@@ -8,8 +9,31 @@ import { type Address } from 'viem'
 import {
   BOOST_PASS_CONTRACT,
   BOOST_PASS_ABI,
+  COMPLETE_BOOST_ABI,
   DATA_ABI_PARAMS,
+  QUEST_FACTORY_CONTRACT,
 } from './constants'
+
+export const complete = async (
+  complete: CompleteActionParams,
+): Promise<TransactionFilter> => {
+  const { chainId, boostId, actionType } = complete
+
+  return compressJson({
+    chainId,
+    to: QUEST_FACTORY_CONTRACT,
+    input: {
+      $abi: COMPLETE_BOOST_ABI,
+      compressedData_: {
+        $and: [
+          // decompress data and compare to incoming value
+          {$compareCompressed: { value: boostId }},
+          {$compareCompressed: { value: actionType }},
+        ],
+      },
+    },
+  })
+}
 
 export const mint = async (
   mint: MintActionParams,

--- a/packages/boost/src/Boost.ts
+++ b/packages/boost/src/Boost.ts
@@ -1,18 +1,18 @@
 import {
-  type TransactionFilter,
-  type MintActionParams,
-  type CompleteActionParams,
-  compressJson,
-} from '@rabbitholegg/questdk'
-import { Chains } from '@rabbitholegg/questdk-plugin-utils'
-import { type Address } from 'viem'
-import {
-  BOOST_PASS_CONTRACT,
   BOOST_PASS_ABI,
+  BOOST_PASS_CONTRACT,
   COMPLETE_BOOST_ABI,
   DATA_ABI_PARAMS,
   QUEST_FACTORY_CONTRACT,
 } from './constants'
+import {
+  type CompleteActionParams,
+  type MintActionParams,
+  type TransactionFilter,
+  compressJson,
+} from '@rabbitholegg/questdk'
+import { Chains } from '@rabbitholegg/questdk-plugin-utils'
+import { type Address } from 'viem'
 
 export const complete = async (
   complete: CompleteActionParams,
@@ -27,8 +27,8 @@ export const complete = async (
       compressedData_: {
         $and: [
           // decompress data and compare to incoming value
-          {$compareCompressed: { value: boostId }},
-          {$compareCompressed: { value: actionType }},
+          { $compareCompressed: { value: boostId } },
+          { $compareCompressed: { value: actionType } },
         ],
       },
     },

--- a/packages/boost/src/constants.ts
+++ b/packages/boost/src/constants.ts
@@ -1,4 +1,6 @@
 export const BOOST_PASS_CONTRACT = '0x9A618D6302f27cdBb97206Ce269A31C1F7da3913'
+export const QUEST_FACTORY_CONTRACT =
+  '0x52629961f71c1c2564c5aa22372cb1b9fa9eba3e'
 
 export const BOOST_PASS_ABI = [
   {
@@ -14,3 +16,13 @@ export const BOOST_PASS_ABI = [
 ]
 
 export const DATA_ABI_PARAMS = ['address recipient', 'address referrer']
+
+export const COMPLETE_BOOST_ABI = [
+  {
+    inputs: [{ internalType: 'bytes', name: 'compressedData_', type: 'bytes' }],
+    name: 'claimCompressed',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+]

--- a/packages/boost/src/index.ts
+++ b/packages/boost/src/index.ts
@@ -3,12 +3,13 @@ import {
   PluginActionNotImplementedError,
 } from '@rabbitholegg/questdk'
 
-import { mint, getSupportedChainIds, getSupportedTokenAddresses } from './Boost'
+import { complete, getSupportedChainIds, getSupportedTokenAddresses, mint } from './Boost'
 
 export const Boost: IActionPlugin = {
   pluginId: 'boost',
   getSupportedTokenAddresses,
   getSupportedChainIds,
+  complete,
   bridge: async () => new PluginActionNotImplementedError(),
   swap: async () => new PluginActionNotImplementedError(),
   mint,

--- a/packages/boost/src/index.ts
+++ b/packages/boost/src/index.ts
@@ -3,7 +3,12 @@ import {
   PluginActionNotImplementedError,
 } from '@rabbitholegg/questdk'
 
-import { complete, getSupportedChainIds, getSupportedTokenAddresses, mint } from './Boost'
+import {
+  complete,
+  getSupportedChainIds,
+  getSupportedTokenAddresses,
+  mint,
+} from './Boost'
 
 export const Boost: IActionPlugin = {
   pluginId: 'boost',

--- a/packages/boost/src/test-transactions.ts
+++ b/packages/boost/src/test-transactions.ts
@@ -1,8 +1,12 @@
-import { type MintActionParams } from '@rabbitholegg/questdk'
+import type {
+  CompleteActionParams,
+  MintActionParams,
+} from '@rabbitholegg/questdk'
 import {
   createTestCase,
   type TestParams,
   Chains,
+  ActionType,
 } from '@rabbitholegg/questdk-plugin-utils'
 
 export const BOOST_PASS_MINT: TestParams<MintActionParams> = {
@@ -22,15 +26,61 @@ export const BOOST_PASS_MINT: TestParams<MintActionParams> = {
   },
 }
 
-export const passingTestCases = [
+export const COMPLETE_BOOST_MINT: TestParams<CompleteActionParams> = {
+  transaction: {
+    chainId: 10,
+    from: '0xa99f898530df1514a566f1a6562d62809e99557d',
+    to: '0x52629961f71c1c2564c5aa22372cb1b9fa9eba3e',
+    hash: '0xd9b8f3cf9b0b972d08359cf9d2ec763216f45cae1bae41e125bc03d12b74eb7f',
+    input:
+      '0xa2e445930000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000007741a6f952d17ea6d90bee54f3162fc2d96abe847aabbdf55965496978eb9fd0ba10726bf45e2fd173074865a21b724074531f92d7b6462ff2a4269d8179c051ed1bc5fd717659d7a28702e79f02c315fa6d3f673dc73b730dc8bf0e5c6148cd0f001f5eaba33a796a4bc990d316b795020000f3002d2105000000000000000000',
+    value: '75000000000000',
+  },
+  params: {
+    chainId: '0xa',
+    boostId: '5eaba33a-796a-4bc9-90d3-16b7950200f3',
+    actionType: ActionType.Mint,
+  },
+}
+
+export const passingTestCasesMint = [
   createTestCase(BOOST_PASS_MINT, 'when minting a boostpass'),
 ]
 
-export const failingTestCases = [
+export const failingTestCasesMint = [
   createTestCase(BOOST_PASS_MINT, 'when chainId is not correct', {
     chainId: Chains.OPTIMISM,
   }),
   createTestCase(BOOST_PASS_MINT, 'when recipient is not correct', {
     recipient: '0x0487bc0f676433e1e245450a94ce1052758bd182',
+  }),
+]
+
+export const passingTestCasesComplete = [
+  createTestCase(COMPLETE_BOOST_MINT, 'when completing a boostpass'),
+  createTestCase(COMPLETE_BOOST_MINT, 'when actionType is "any"', {
+    actionType: undefined,
+  }),
+  createTestCase(COMPLETE_BOOST_MINT, 'when boostId is "any"', {
+    boostId: undefined,
+  }),
+  createTestCase(COMPLETE_BOOST_MINT, 'when chain is "any"', {
+    chainId: undefined,
+  }),
+  createTestCase(COMPLETE_BOOST_MINT, 'when actionType and boostId are "any"', {
+    actionType: undefined,
+    boostId: undefined,
+  }),
+]
+
+export const failingTestCasesComplete = [
+  createTestCase(COMPLETE_BOOST_MINT, 'when chainId is not correct', {
+    chainId: '0x1',
+  }),
+  createTestCase(COMPLETE_BOOST_MINT, 'when actionType is not correct', {
+    actionType: ActionType.Swap,
+  }),
+  createTestCase(COMPLETE_BOOST_MINT, 'when boostId is not correct', {
+    boostId: '0x0487bc0f676433e1e245450a94ce1052758bd182',
   }),
 ]

--- a/packages/boost/src/test-transactions.ts
+++ b/packages/boost/src/test-transactions.ts
@@ -3,10 +3,10 @@ import type {
   MintActionParams,
 } from '@rabbitholegg/questdk'
 import {
-  createTestCase,
-  type TestParams,
-  Chains,
   ActionType,
+  Chains,
+  type TestParams,
+  createTestCase,
 } from '@rabbitholegg/questdk-plugin-utils'
 
 export const BOOST_PASS_MINT: TestParams<MintActionParams> = {


### PR DESCRIPTION
## Integration of `boost` complete action plugin for QuestDK

This PR introduces the integration of the `boost` complete plugin for QuestDK.

## Implementation 
The complete boost plugin uses the complete ActionType, specifically designed for this use case. The claim transaction inputs contain compressed data, which includes the information needed to compare to the parameters (actionType/boostId). To decompress and compare this data, we need to create a custom operator (referred to as $compareCompressed in the PR) and add logic to [filters.ts in the SDK](https://github.com/rabbitholegg/questdk-plugins/blob/6eb5baedc5fa16b9b46bfe322a08da3c47d08b90/apps/questdk/src/filter/filters.ts) to decode and compare the compressed data to the parameters.

## Sample Transactions
- [claimCompressed](https://optimistic.etherscan.io/tx/0xd9b8f3cf9b0b972d08359cf9d2ec763216f45cae1bae41e125bc03d12b74eb7f)