### PR TITLE
chore: mark third party sdks as external in build

### DIFF
--- a/.changeset/gorgeous-horses-vanish.md
+++ b/.changeset/gorgeous-horses-vanish.md
@@ -1,0 +1,12 @@
+---
+"@rabbitholegg/questdk-plugin-optimism": patch
+"@rabbitholegg/questdk-plugin-connext": patch
+"@rabbitholegg/questdk-plugin-polygon": patch
+"@rabbitholegg/questdk-plugin-uniswap": patch
+"@rabbitholegg/questdk-plugin-sushi": patch
+"@rabbitholegg/questdk-plugin-zora": patch
+"@rabbitholegg/questdk-plugin-hop": patch
+"@rabbitholegg/questdk-plugin-mux": patch
+---
+
+mark third party sdk's as external dependencies

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Our build process now consists of three discrete steps, designed to ensure both 
 
 ### Additional Updates
 
+- **Third-party SDK's**: If a plugin is dependent on a third party SDK, like `@zoralabs/protocol-sdk`, please ensure that a matching package name regular expression, ie: `/@zoralabs/` is added to the plugin's `vite.config.js` `build.rollupOptions.external` to prevent unnecessary inclusion in compiled output.
 - **Migration Away from Rome**: Recognizing that Rome is no longer maintained, we've started to migrate our tooling away from it to ensure future compatibility and support.
 - **Utility Script for File Management**: To facilitate cleaner updates, a helper script has been added for copying files out to every directory. This approach allows for a more straightforward "delete all and replace" strategy when updating modules.
 

--- a/packages/connext/vite.config.js
+++ b/packages/connext/vite.config.js
@@ -2,7 +2,7 @@
 export default {
   build: {
     rollupOptions: {
-      external: [/@rabbitholegg/],
+      external: [/@rabbitholegg/, /@connext/],
     },
     lib: {
       entry: 'src/index.ts',

--- a/packages/hop/vite.config.js
+++ b/packages/hop/vite.config.js
@@ -2,7 +2,7 @@
 export default {
   build: {
     rollupOptions: {
-      external: [/@rabbitholegg/],
+      external: [/@rabbitholegg/, /@hop-protocol/],
     },
     lib: {
       entry: 'src/index.ts',

--- a/packages/mux/vite.config.js
+++ b/packages/mux/vite.config.js
@@ -2,7 +2,7 @@
 export default {
   build: {
     rollupOptions: {
-      external: [/@rabbitholegg/],
+      external: [/@rabbitholegg/, /@mux-network/],
     },
     lib: {
       entry: 'src/index.ts',

--- a/packages/optimism/vite.config.js
+++ b/packages/optimism/vite.config.js
@@ -2,7 +2,7 @@
 export default {
   build: {
     rollupOptions: {
-      external: [/@rabbitholegg/],
+      external: [/@rabbitholegg/, /@eth-optimism/],
     },
     lib: {
       entry: 'src/index.ts',

--- a/packages/polygon/vite.config.js
+++ b/packages/polygon/vite.config.js
@@ -2,7 +2,7 @@
 export default {
   build: {
     rollupOptions: {
-      external: [/@rabbitholegg/],
+      external: [/@rabbitholegg/, /@maticnetwork/],
     },
     lib: {
       entry: 'src/index.ts',

--- a/packages/sushi/vite.config.js
+++ b/packages/sushi/vite.config.js
@@ -2,7 +2,7 @@
 export default {
   build: {
     rollupOptions: {
-      external: [/@rabbitholegg/],
+      external: [/@rabbitholegg/, /@sushiswap/],
     },
     lib: {
       entry: 'src/index.ts',

--- a/packages/uniswap/vite.config.js
+++ b/packages/uniswap/vite.config.js
@@ -2,7 +2,7 @@
 export default {
   build: {
     rollupOptions: {
-      external: [/@rabbitholegg/],
+      external: [/@rabbitholegg/, /@uniswap/],
     },
     lib: {
       entry: 'src/index.ts',

--- a/packages/zora/vite.config.js
+++ b/packages/zora/vite.config.js
@@ -2,7 +2,7 @@
 export default {
   build: {
     rollupOptions: {
-      external: [/@rabbitholegg/],
+      external: [/@rabbitholegg/, /@zoralabs/],
     },
     lib: {
       entry: 'src/index.ts',


### PR DESCRIPTION
up until now, we've been compiling third party sdk's as a part of our builds AND specifying them as production dependencies, which means downstream consumers are still downloading the package even though they aren't imported in the published bundle.

this change preserves imports/requires for those sdk's in our build artifacts, thereby deferring to downstream bundlers as far as how to best resolve those dependencies

the end result is faster build times, less memory overhead in ci, and smaller bundles