### PR TITLE
fix(utils): use named imports for helpers

### DIFF
--- a/.changeset/moody-yaks-rest.md
+++ b/.changeset/moody-yaks-rest.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-utils": minor
+---
+
+fix utils exports

--- a/packages/utils/src/helpers/index.ts
+++ b/packages/utils/src/helpers/index.ts
@@ -1,4 +1,4 @@
 export { createTestCase } from './test-helpers'
 export type { TestCase, TestParams } from './test-helpers'
 export { chainIdToViemChain } from './chain-id-to-viem-chain'
-export * from './get-exit-addresses'
+export { getExitAddresses } from './get-exit-addresses'

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -7,7 +7,7 @@ export {
 
 export type { TestParams, TestCase } from './helpers/index'
 
-export { createTestCase, chainIdToViemChain, getExitAddresses } from './helpers'
+export { chainIdToViemChain, createTestCase, getExitAddresses } from './helpers'
 export type {
   IntentParams,
   MintIntentParams,

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -7,7 +7,7 @@ export {
 
 export type { TestParams, TestCase } from './helpers/index'
 
-export * from './helpers'
+export { createTestCase, chainIdToViemChain, getExitAddresses } from './helpers'
 export type {
   IntentParams,
   MintIntentParams,


### PR DESCRIPTION
Exports in the utils package are not working when using namespace exports (export * from package).