### PR TITLE
feat(neynar): support usernames, channel id's as validation targets

### DIFF
--- a/.changeset/cuddly-emus-confess.md
+++ b/.changeset/cuddly-emus-confess.md
@@ -1,0 +1,6 @@
+---
+"@rabbitholegg/questdk-plugin-neynar": minor
+"@rabbitholegg/questdk-plugin-utils": minor
+---
+
+Change validateFollow to accept usernames/channel strings or fid's as numbers, fetchUser to accept numerical fid's

--- a/packages/neynar/src/Neynar.test.ts
+++ b/packages/neynar/src/Neynar.test.ts
@@ -78,13 +78,15 @@ describe('validateFollow function', () => {
   })
 
   it('should return true if the actor is a follower of the target user', async () => {
-    (axios.get as MockedFunction<typeof axios.get>).mockResolvedValueOnce({
-      status: 200,
-      data: MockedUserSearchSchema,
-    }).mockResolvedValueOnce({
-      status: 200,
-      data: { channels: [] },
-    })
+    ;(axios.get as MockedFunction<typeof axios.get>)
+      .mockResolvedValueOnce({
+        status: 200,
+        data: MockedUserSearchSchema,
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        data: { channels: [] },
+      })
 
     const result = await validateFollow(
       { target: 'target_fid' },
@@ -94,20 +96,30 @@ describe('validateFollow function', () => {
   })
 
   it('should return true if the actor is a follower of the target channel', async () => {
-    (axios.get as MockedFunction<typeof axios.get>).mockResolvedValueOnce({
-      status: 200,
-      data: { result: {users:[{
-        object: 'user',
-        fid: 1,
-        username: 'actor',
-        viewer_context: {
-          following: false,
+    ;(axios.get as MockedFunction<typeof axios.get>)
+      .mockResolvedValueOnce({
+        status: 200,
+        data: {
+          result: {
+            users: [
+              {
+                object: 'user',
+                fid: 1,
+                username: 'actor',
+                viewer_context: {
+                  following: false,
+                },
+              },
+            ],
+          },
         },
-      }]}},
-    }).mockResolvedValueOnce({
-      status: 200,
-      data: { channels: [{id: '', name:'', viewer_context: { following: true}}] } as ChannelsResponse,
-    })
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        data: {
+          channels: [{ id: '', name: '', viewer_context: { following: true } }],
+        } as ChannelsResponse,
+      })
 
     const result = await validateFollow(
       { target: 'target_fid' },
@@ -117,7 +129,7 @@ describe('validateFollow function', () => {
   })
 
   it('should return false if the actor is not a follower of the target', async () => {
-    (axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
+    ;(axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
       status: 200,
       data: {},
     })
@@ -130,7 +142,7 @@ describe('validateFollow function', () => {
   })
 
   it('should return false on API failure', async () => {
-    (axios.get as MockedFunction<typeof axios.get>).mockRejectedValue(
+    ;(axios.get as MockedFunction<typeof axios.get>).mockRejectedValue(
       new Error('API failure'),
     )
 
@@ -148,7 +160,7 @@ describe('validateRecast function', () => {
   })
 
   it('should return true if the actor has recast the target', async () => {
-    (axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
+    ;(axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
       status: 200,
       data: MockedConversationResponseSchema,
     })
@@ -161,7 +173,7 @@ describe('validateRecast function', () => {
   })
 
   it('should return false if the actor has not recast the target', async () => {
-    (axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
+    ;(axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
       status: 200,
       data: MockedConversationHasntRecastResponseSchema,
     })
@@ -174,7 +186,7 @@ describe('validateRecast function', () => {
   })
 
   it('should return false on API failure', async () => {
-    (axios.get as MockedFunction<typeof axios.get>).mockRejectedValue(
+    ;(axios.get as MockedFunction<typeof axios.get>).mockRejectedValue(
       new Error('API failure'),
     )
 
@@ -188,7 +200,7 @@ describe('validateRecast function', () => {
 
 describe('translateAddressToFID function', () => {
   it('should return the custody address if the input is a valid address', async () => {
-    (axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
+    ;(axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
       status: 200,
       data: {
         '0xB2f784dCC11a696D8f54dC1692fEb2b660959A6A': [
@@ -211,7 +223,7 @@ describe('translateAddressToFID function', () => {
   })
 
   it('should return null if the API response does not contain a custody address', async () => {
-    (axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
+    ;(axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
       status: 200,
       data: [{}],
     })

--- a/packages/neynar/src/Neynar.ts
+++ b/packages/neynar/src/Neynar.ts
@@ -130,8 +130,6 @@ const fetchChannel = async (
     },
   })
 
-  console.log('fetchChannel', response.data)
-
   // Validate the response data with the Zod schema
   const parsedResponse: ChannelsResponse = ChannelsResponseSchema.parse(
     response.data,

--- a/packages/neynar/src/Neynar.ts
+++ b/packages/neynar/src/Neynar.ts
@@ -86,16 +86,27 @@ export const validateFollow = async (
     const actorFid: number | null =
       (await translateAddressToFID(validateP.actor)) || Number(validateP.actor)
 
-    const [userResponse, channelResponse] = await Promise.allSettled(
-      [fetchUser(actionP.target, actorFid), (async () => {
-        if(typeof actionP.target === 'string') return await fetchChannel(actionP.target, actorFid)
+    const [userResponse, channelResponse] = await Promise.allSettled([
+      fetchUser(actionP.target, actorFid),
+      (async () => {
+        if (typeof actionP.target === 'string')
+          return await fetchChannel(actionP.target, actorFid)
+        // return a stubbed empty response for consistent type return
         return { channels: [] } as ChannelsResponse
-      })()],
-    )
+      })(),
+    ])
 
     // there is an edge case where a user could have the same username as a channel id, and if they're following that user then this will validate
-    if(channelResponse.status === 'fulfilled' && channelResponse.value.channels.at(0)?.viewer_context.following) return true
-    if(userResponse.status === 'fulfilled' && userResponse.value?.viewer_context.following) return true
+    if (
+      channelResponse.status === 'fulfilled' &&
+      channelResponse.value.channels.at(0)?.viewer_context.following
+    )
+      return true
+    if (
+      userResponse.status === 'fulfilled' &&
+      userResponse.value?.viewer_context.following
+    )
+      return true
 
     return false
   } catch (error) {
@@ -142,14 +153,14 @@ const fetchUser = async (
   actorFid: number,
 ): Promise<User | undefined> => {
   // if we're searching with an FID, use the bulk endpoint
-  if(typeof target === 'number') {
+  if (typeof target === 'number') {
     const response = await axiosInstance.get('/user/bulk', {
       params: {
         fids: target,
         viewer_fid: actorFid,
       },
     })
-  
+
     // Validate the response data with the Zod schema
     const parsedResponse: UsersResponse = UsersResponseSchema.parse(
       response.data,
@@ -167,9 +178,7 @@ const fetchUser = async (
   })
 
   // Validate the response data with the Zod schema
-  const parsedResponse: UserSearch = UserSearchSchema.parse(
-    response.data,
-  )
+  const parsedResponse: UserSearch = UserSearchSchema.parse(response.data)
   return parsedResponse.result.users.at(0)
 }
 

--- a/packages/neynar/src/Neynar.ts
+++ b/packages/neynar/src/Neynar.ts
@@ -93,8 +93,6 @@ export const validateFollow = async (
       })()],
     )
 
-    console.log(userResponse, channelResponse)
-
     // there is an edge case where a user could have the same username as a channel id, and if they're following that user then this will validate
     if(channelResponse.status === 'fulfilled' && channelResponse.value.channels.at(0)?.viewer_context.following) return true
     if(userResponse.status === 'fulfilled' && userResponse.value?.viewer_context.following) return true

--- a/packages/neynar/src/Neynar.ts
+++ b/packages/neynar/src/Neynar.ts
@@ -10,10 +10,15 @@ import {
 } from '@rabbitholegg/questdk-plugin-utils'
 import { type Address } from 'viem'
 import {
+  ChannelsResponse,
+  ChannelsResponseSchema,
   ConversationResponse,
   ConversationResponseSchema,
-  FollowersResponse,
-  FollowersResponseSchema,
+  User,
+  UsersResponse,
+  UsersResponseSchema,
+  UserSearch,
+  UserSearchSchema,
 } from './types'
 import { isAddress } from 'viem'
 import assert from 'node:assert'
@@ -81,9 +86,18 @@ export const validateFollow = async (
     const actorFid: number | null =
       (await translateAddressToFID(validateP.actor)) || Number(validateP.actor)
 
-    const response = await fetchUser(actionP.target, actorFid)
-    if (response.users[0].viewer_context.following)
-      return response.users[0].viewer_context.following
+    const [userResponse, channelResponse] = await Promise.allSettled(
+      [fetchUser(actionP.target, actorFid), (async () => {
+        if(typeof actionP.target === 'string') return await fetchChannel(actionP.target, actorFid)
+        return { channels: [] } as ChannelsResponse
+      })()],
+    )
+
+    console.log(userResponse, channelResponse)
+
+    // there is an edge case where a user could have the same username as a channel id, and if they're following that user then this will validate
+    if(channelResponse.status === 'fulfilled' && channelResponse.value.channels.at(0)?.viewer_context.following) return true
+    if(userResponse.status === 'fulfilled' && userResponse.value?.viewer_context.following) return true
 
     return false
   } catch (error) {
@@ -106,22 +120,61 @@ export const validateRecast = async (
   }
 }
 
-const fetchUser = async (
+const fetchChannel = async (
   target: string,
   actorFid: number,
-): Promise<FollowersResponse> => {
-  const response = await axiosInstance.get('/user/bulk', {
+): Promise<ChannelsResponse> => {
+  const response = await axiosInstance.get('/channel/bulk', {
     params: {
-      fids: target,
+      ids: target,
+      type: 'id',
       viewer_fid: actorFid,
     },
   })
 
+  console.log('fetchChannel', response.data)
+
   // Validate the response data with the Zod schema
-  const parsedResponse: FollowersResponse = FollowersResponseSchema.parse(
+  const parsedResponse: ChannelsResponse = ChannelsResponseSchema.parse(
     response.data,
   )
   return parsedResponse
+}
+
+const fetchUser = async (
+  target: string | number,
+  actorFid: number,
+): Promise<User | undefined> => {
+  // if we're searching with an FID, use the bulk endpoint
+  if(typeof target === 'number') {
+    const response = await axiosInstance.get('/user/bulk', {
+      params: {
+        fids: target,
+        viewer_fid: actorFid,
+      },
+    })
+  
+    // Validate the response data with the Zod schema
+    const parsedResponse: UsersResponse = UsersResponseSchema.parse(
+      response.data,
+    )
+    return parsedResponse?.users?.at(0)
+  }
+
+  // otherwise search by username, there should only be one if the username is correct
+  const response = await axiosInstance.get('/user/search', {
+    params: {
+      q: target,
+      viewer_fid: actorFid,
+      limit: '1',
+    },
+  })
+
+  // Validate the response data with the Zod schema
+  const parsedResponse: UserSearch = UserSearchSchema.parse(
+    response.data,
+  )
+  return parsedResponse.result.users.at(0)
 }
 
 const fetchConversation = async (

--- a/packages/neynar/src/types.ts
+++ b/packages/neynar/src/types.ts
@@ -25,22 +25,24 @@ export type User = z.infer<typeof UserSchema>
 export type UserSearch = z.infer<typeof UserSearchSchema>
 
 // this is a partial schema solely to support recasts
-export const ConversationSchema = z.object({
-  cast: z.object({
-    reactions: z.object({
-      recasts: z.array(
-        z.object({
-          fid: z.number(),
-          fname: z.string(),
-        }),
-      ),
+export const ConversationSchema = z
+  .object({
+    cast: z.object({
+      reactions: z.object({
+        recasts: z.array(
+          z.object({
+            fid: z.number(),
+            fname: z.string(),
+          }),
+        ),
+      }),
+      viewer_context: z.object({
+        liked: z.boolean().optional(),
+        recasted: z.boolean().optional(),
+      }),
     }),
-    viewer_context: z.object({
-      liked: z.boolean().optional(),
-      recasted: z.boolean().optional(),
-    }),
-  }),
-}).passthrough()
+  })
+  .passthrough()
 
 // see https://github.com/neynarxyz/OAS/blob/4012289342260697c85dd373b7e459e76626b151/src/v2/spec.yaml#L714
 export const ConversationResponseSchema = z.object({
@@ -52,18 +54,22 @@ export type Conversation = z.infer<typeof ConversationSchema>
 
 // this is a partial schema solely to support following
 // https://github.com/neynarxyz/OAS/blob/4012289342260697c85dd373b7e459e76626b151/src/v2/spec.yaml#L907
-export const ChannelSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  viewer_context: z.object({
-    following: z.boolean().optional(),
-  }),
-}).passthrough()
+export const ChannelSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    viewer_context: z.object({
+      following: z.boolean().optional(),
+    }),
+  })
+  .passthrough()
 
 // see https://github.com/neynarxyz/OAS/blob/4012289342260697c85dd373b7e459e76626b151/src/v2/spec.yaml#L964
-export const ChannelsResponseSchema = z.object({
-  channels: z.array(ChannelSchema),
-}).passthrough()
+export const ChannelsResponseSchema = z
+  .object({
+    channels: z.array(ChannelSchema),
+  })
+  .passthrough()
 
 export type ChannelsResponse = z.infer<typeof ChannelsResponseSchema>
 export type Channel = z.infer<typeof ChannelSchema>

--- a/packages/neynar/src/types.ts
+++ b/packages/neynar/src/types.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-export const FollowerSchema = z
+export const UserSchema = z
   .object({
     object: z.string(),
     custody_address: z.string().optional(),
@@ -12,12 +12,17 @@ export const FollowerSchema = z
   })
   .passthrough()
 
-export const FollowersResponseSchema = z.object({
-  users: z.array(FollowerSchema),
+export const UsersResponseSchema = z.object({
+  users: z.array(UserSchema),
 })
 
-export type FollowersResponse = z.infer<typeof FollowersResponseSchema>
-export type Follower = z.infer<typeof FollowerSchema>
+export const UserSearchSchema = z.object({
+  result: UsersResponseSchema,
+})
+
+export type UsersResponse = z.infer<typeof UsersResponseSchema>
+export type User = z.infer<typeof UserSchema>
+export type UserSearch = z.infer<typeof UserSearchSchema>
 
 // this is a partial schema solely to support recasts
 export const ConversationSchema = z.object({
@@ -35,7 +40,7 @@ export const ConversationSchema = z.object({
       recasted: z.boolean().optional(),
     }),
   }),
-})
+}).passthrough()
 
 // see https://github.com/neynarxyz/OAS/blob/4012289342260697c85dd373b7e459e76626b151/src/v2/spec.yaml#L714
 export const ConversationResponseSchema = z.object({
@@ -44,3 +49,21 @@ export const ConversationResponseSchema = z.object({
 
 export type ConversationResponse = z.infer<typeof ConversationResponseSchema>
 export type Conversation = z.infer<typeof ConversationSchema>
+
+// this is a partial schema solely to support following
+// https://github.com/neynarxyz/OAS/blob/4012289342260697c85dd373b7e459e76626b151/src/v2/spec.yaml#L907
+export const ChannelSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  viewer_context: z.object({
+    following: z.boolean().optional(),
+  }),
+}).passthrough()
+
+// see https://github.com/neynarxyz/OAS/blob/4012289342260697c85dd373b7e459e76626b151/src/v2/spec.yaml#L964
+export const ChannelsResponseSchema = z.object({
+  channels: z.array(ChannelSchema),
+}).passthrough()
+
+export type ChannelsResponse = z.infer<typeof ChannelsResponseSchema>
+export type Channel = z.infer<typeof ChannelSchema>

--- a/packages/utils/src/types/actions.ts
+++ b/packages/utils/src/types/actions.ts
@@ -227,7 +227,7 @@ FOLLOW
 */
 export type FollowActionParams = {
   // if the target is a string, then assume it's a valid username or channel name
-  // if it's a number, assume it's a fid, but that will rarely be the case 
+  // if it's a number, assume it's a fid, but that will rarely be the case
   target: Address | string | number
   project?: Address | string
 }
@@ -242,7 +242,7 @@ export type FollowValidationParams = z.infer<
 
 export const FollowActionDetailSchema = z.object({
   // if the target is a string, then assume it's a valid username or channel name
-  // if it's a number, assume it's a fid, but that will rarely be the case 
+  // if it's a number, assume it's a fid, but that will rarely be the case
   target: z.union([z.string(), EthAddressSchema, z.number()]),
   project: z.union([z.string(), EthAddressSchema]).optional(),
 })
@@ -250,7 +250,7 @@ export type FollowActionDetail = z.infer<typeof FollowActionDetailSchema>
 
 export const FollowActionFormSchema = z.object({
   // if the target is a string, then assume it's a valid username or channel name
-  // if it's a number, assume it's a fid, but that will rarely be the case 
+  // if it's a number, assume it's a fid, but that will rarely be the case
   target: z.union([z.string(), EthAddressSchema, z.number()]),
 })
 export type FollowActionForm = z.infer<typeof FollowActionFormSchema>

--- a/packages/utils/src/types/actions.ts
+++ b/packages/utils/src/types/actions.ts
@@ -226,7 +226,9 @@ export type MintActionForm = z.infer<typeof MintActionFormSchema>
 FOLLOW
 */
 export type FollowActionParams = {
-  target: Address | string // Might want a more precise type here for FID?
+  // if the target is a string, then assume it's a valid username or channel name
+  // if it's a number, assume it's a fid, but that will rarely be the case 
+  target: Address | string | number
   project?: Address | string
 }
 
@@ -239,13 +241,17 @@ export type FollowValidationParams = z.infer<
 >
 
 export const FollowActionDetailSchema = z.object({
-  target: z.union([z.string(), EthAddressSchema]),
+  // if the target is a string, then assume it's a valid username or channel name
+  // if it's a number, assume it's a fid, but that will rarely be the case 
+  target: z.union([z.string(), EthAddressSchema, z.number()]),
   project: z.union([z.string(), EthAddressSchema]).optional(),
 })
 export type FollowActionDetail = z.infer<typeof FollowActionDetailSchema>
 
 export const FollowActionFormSchema = z.object({
-  target: z.union([z.string(), EthAddressSchema]),
+  // if the target is a string, then assume it's a valid username or channel name
+  // if it's a number, assume it's a fid, but that will rarely be the case 
+  target: z.union([z.string(), EthAddressSchema, z.number()]),
 })
 export type FollowActionForm = z.infer<typeof FollowActionFormSchema>
 


### PR DESCRIPTION
- add `fetchChannel` function
- execute `fetchChannel` and `fetchUser` in parallel for `validateFollow`
- refactor `Follow` naming to `User` name scheme to be more in line with Neynar API