### PR TITLE
feat(neynar): differentiate channel from user in follow action

### DIFF
--- a/.changeset/curvy-brooms-cry.md
+++ b/.changeset/curvy-brooms-cry.md
@@ -1,0 +1,6 @@
+---
+"@rabbitholegg/questdk-plugin-neynar": minor
+"@rabbitholegg/questdk-plugin-utils": minor
+---
+
+add type to follow params to differentiate channel from user

--- a/packages/neynar/src/Neynar.test.ts
+++ b/packages/neynar/src/Neynar.test.ts
@@ -78,7 +78,7 @@ describe('validateFollow function', () => {
   })
 
   it('should return true if the actor is a follower of the target user', async () => {
-    (axios.get as MockedFunction<typeof axios.get>)
+    ;(axios.get as MockedFunction<typeof axios.get>)
       .mockResolvedValueOnce({
         status: 200,
         data: MockedUserSearchSchema,
@@ -96,13 +96,12 @@ describe('validateFollow function', () => {
   })
 
   it('should return true if the actor is a follower of the target channel', async () => {
-    (axios.get as MockedFunction<typeof axios.get>)
-      .mockResolvedValueOnce({
-        status: 200,
-        data: {
-          channels: [{ id: '', name: '', viewer_context: { following: true } }],
-        } as ChannelsResponse,
-      })
+    ;(axios.get as MockedFunction<typeof axios.get>).mockResolvedValueOnce({
+      status: 200,
+      data: {
+        channels: [{ id: '', name: '', viewer_context: { following: true } }],
+      } as ChannelsResponse,
+    })
 
     const result = await validateFollow(
       { target: 'target_fid', type: 'channel' },
@@ -112,7 +111,7 @@ describe('validateFollow function', () => {
   })
 
   it('should return false if the actor is not a follower of the target', async () => {
-    (axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
+    ;(axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
       status: 200,
       data: {},
     })
@@ -125,7 +124,7 @@ describe('validateFollow function', () => {
   })
 
   it('should return false on API failure', async () => {
-    (axios.get as MockedFunction<typeof axios.get>).mockRejectedValue(
+    ;(axios.get as MockedFunction<typeof axios.get>).mockRejectedValue(
       new Error('API failure'),
     )
 
@@ -143,7 +142,7 @@ describe('validateRecast function', () => {
   })
 
   it('should return true if the actor has recast the target', async () => {
-    (axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
+    ;(axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
       status: 200,
       data: MockedConversationResponseSchema,
     })
@@ -156,7 +155,7 @@ describe('validateRecast function', () => {
   })
 
   it('should return false if the actor has not recast the target', async () => {
-    (axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
+    ;(axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
       status: 200,
       data: MockedConversationHasntRecastResponseSchema,
     })
@@ -169,7 +168,7 @@ describe('validateRecast function', () => {
   })
 
   it('should return false on API failure', async () => {
-    (axios.get as MockedFunction<typeof axios.get>).mockRejectedValue(
+    ;(axios.get as MockedFunction<typeof axios.get>).mockRejectedValue(
       new Error('API failure'),
     )
 
@@ -183,7 +182,7 @@ describe('validateRecast function', () => {
 
 describe('translateAddressToFID function', () => {
   it('should return the custody address if the input is a valid address', async () => {
-    (axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
+    ;(axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
       status: 200,
       data: {
         '0xB2f784dCC11a696D8f54dC1692fEb2b660959A6A': [
@@ -206,7 +205,7 @@ describe('translateAddressToFID function', () => {
   })
 
   it('should return null if the API response does not contain a custody address', async () => {
-    (axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
+    ;(axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
       status: 200,
       data: [{}],
     })

--- a/packages/neynar/src/Neynar.test.ts
+++ b/packages/neynar/src/Neynar.test.ts
@@ -78,7 +78,7 @@ describe('validateFollow function', () => {
   })
 
   it('should return true if the actor is a follower of the target user', async () => {
-    ;(axios.get as MockedFunction<typeof axios.get>)
+    (axios.get as MockedFunction<typeof axios.get>)
       .mockResolvedValueOnce({
         status: 200,
         data: MockedUserSearchSchema,
@@ -89,31 +89,14 @@ describe('validateFollow function', () => {
       })
 
     const result = await validateFollow(
-      { target: 'target_fid' },
+      { target: 'target_fid', type: 'user' },
       { actor: '1' },
     )
     expect(result).toBe(true)
   })
 
   it('should return true if the actor is a follower of the target channel', async () => {
-    ;(axios.get as MockedFunction<typeof axios.get>)
-      .mockResolvedValueOnce({
-        status: 200,
-        data: {
-          result: {
-            users: [
-              {
-                object: 'user',
-                fid: 1,
-                username: 'actor',
-                viewer_context: {
-                  following: false,
-                },
-              },
-            ],
-          },
-        },
-      })
+    (axios.get as MockedFunction<typeof axios.get>)
       .mockResolvedValueOnce({
         status: 200,
         data: {
@@ -122,32 +105,32 @@ describe('validateFollow function', () => {
       })
 
     const result = await validateFollow(
-      { target: 'target_fid' },
+      { target: 'target_fid', type: 'channel' },
       { actor: '1' },
     )
     expect(result).toBe(true)
   })
 
   it('should return false if the actor is not a follower of the target', async () => {
-    ;(axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
+    (axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
       status: 200,
       data: {},
     })
 
     const result = await validateFollow(
-      { target: '3' },
+      { target: '3', type: 'user' },
       { actor: '0xd7053a3e7f8c02a6939377e2ca32bcc2a23023a1' },
     )
     expect(result).toBe(false)
   })
 
   it('should return false on API failure', async () => {
-    ;(axios.get as MockedFunction<typeof axios.get>).mockRejectedValue(
+    (axios.get as MockedFunction<typeof axios.get>).mockRejectedValue(
       new Error('API failure'),
     )
 
     const result = await validateFollow(
-      { target: 'target_fid' },
+      { target: 'target_fid', type: 'user' },
       { actor: 'actor_address' },
     )
     expect(result).toBe(false)
@@ -160,7 +143,7 @@ describe('validateRecast function', () => {
   })
 
   it('should return true if the actor has recast the target', async () => {
-    ;(axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
+    (axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
       status: 200,
       data: MockedConversationResponseSchema,
     })
@@ -173,7 +156,7 @@ describe('validateRecast function', () => {
   })
 
   it('should return false if the actor has not recast the target', async () => {
-    ;(axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
+    (axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
       status: 200,
       data: MockedConversationHasntRecastResponseSchema,
     })
@@ -186,7 +169,7 @@ describe('validateRecast function', () => {
   })
 
   it('should return false on API failure', async () => {
-    ;(axios.get as MockedFunction<typeof axios.get>).mockRejectedValue(
+    (axios.get as MockedFunction<typeof axios.get>).mockRejectedValue(
       new Error('API failure'),
     )
 
@@ -200,7 +183,7 @@ describe('validateRecast function', () => {
 
 describe('translateAddressToFID function', () => {
   it('should return the custody address if the input is a valid address', async () => {
-    ;(axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
+    (axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
       status: 200,
       data: {
         '0xB2f784dCC11a696D8f54dC1692fEb2b660959A6A': [
@@ -223,7 +206,7 @@ describe('translateAddressToFID function', () => {
   })
 
   it('should return null if the API response does not contain a custody address', async () => {
-    ;(axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
+    (axios.get as MockedFunction<typeof axios.get>).mockResolvedValue({
       status: 200,
       data: [{}],
     })

--- a/packages/neynar/src/Neynar.ts
+++ b/packages/neynar/src/Neynar.ts
@@ -86,27 +86,17 @@ export const validateFollow = async (
     const actorFid: number | null =
       (await translateAddressToFID(validateP.actor)) || Number(validateP.actor)
 
-    const [userResponse, channelResponse] = await Promise.allSettled([
-      fetchUser(actionP.target, actorFid),
-      (async () => {
-        if (typeof actionP.target === 'string')
-          return await fetchChannel(actionP.target, actorFid)
-        // return a stubbed empty response for consistent type return
-        return { channels: [] } as ChannelsResponse
-      })(),
-    ])
+    if(typeof actionP.target === 'string' && actionP.type === 'channel') {
+      const channelResponse = await fetchChannel(actionP.target, actorFid)
+      const channel = channelResponse.channels.at(0)
+      if(!channel) return false
+      return channel.viewer_context.following || false
+    }
 
-    // there is an edge case where a user could have the same username as a channel id, and if they're following that user then this will validate
-    if (
-      channelResponse.status === 'fulfilled' &&
-      channelResponse.value.channels.at(0)?.viewer_context.following
-    )
-      return true
-    if (
-      userResponse.status === 'fulfilled' &&
-      userResponse.value?.viewer_context.following
-    )
-      return true
+    if(typeof actionP.target === 'string' && actionP.type === 'user') {
+      const userResponse = await fetchUser(actionP.target, actorFid)
+      return userResponse?.viewer_context.following || false
+    }
 
     return false
   } catch (error) {

--- a/packages/neynar/src/Neynar.ts
+++ b/packages/neynar/src/Neynar.ts
@@ -86,14 +86,14 @@ export const validateFollow = async (
     const actorFid: number | null =
       (await translateAddressToFID(validateP.actor)) || Number(validateP.actor)
 
-    if(typeof actionP.target === 'string' && actionP.type === 'channel') {
+    if (typeof actionP.target === 'string' && actionP.type === 'channel') {
       const channelResponse = await fetchChannel(actionP.target, actorFid)
       const channel = channelResponse.channels.at(0)
-      if(!channel) return false
+      if (!channel) return false
       return channel.viewer_context.following || false
     }
 
-    if(typeof actionP.target === 'string' && actionP.type === 'user') {
+    if (typeof actionP.target === 'string' && actionP.type === 'user') {
       const userResponse = await fetchUser(actionP.target, actorFid)
       return userResponse?.viewer_context.following || false
     }

--- a/packages/utils/src/types/actions.ts
+++ b/packages/utils/src/types/actions.ts
@@ -229,6 +229,7 @@ export type FollowActionParams = {
   // if the target is a string, then assume it's a valid username or channel name
   // if it's a number, assume it's a fid, but that will rarely be the case
   target: Address | string | number
+  type: 'user' | 'channel'
   project?: Address | string
 }
 
@@ -244,6 +245,7 @@ export const FollowActionDetailSchema = z.object({
   // if the target is a string, then assume it's a valid username or channel name
   // if it's a number, assume it's a fid, but that will rarely be the case
   target: z.union([z.string(), EthAddressSchema, z.number()]),
+  type: z.union([z.literal('user'), z.literal('channel')]),
   project: z.union([z.string(), EthAddressSchema]).optional(),
 })
 export type FollowActionDetail = z.infer<typeof FollowActionDetailSchema>
@@ -252,6 +254,7 @@ export const FollowActionFormSchema = z.object({
   // if the target is a string, then assume it's a valid username or channel name
   // if it's a number, assume it's a fid, but that will rarely be the case
   target: z.union([z.string(), EthAddressSchema, z.number()]),
+  type: z.union([z.literal('user'), z.literal('channel')]),
 })
 export type FollowActionForm = z.infer<typeof FollowActionFormSchema>
 


### PR DESCRIPTION
in the event that a user and a channel have the same name, validation wouldn't work predictably.

adding a `type` field to the action params will solve this issue