### PR TITLE
feat(utils): pass `creatorAddress` into `simulateMint` function

### DIFF
--- a/.changeset/lovely-llamas-float.md
+++ b/.changeset/lovely-llamas-float.md
@@ -1,0 +1,6 @@
+---
+"@rabbitholegg/questdk-plugin-registry": minor
+"@rabbitholegg/questdk-plugin-utils": minor
+---
+
+pass in creator address to simulateMint

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -149,6 +149,7 @@ export const getTxSimulation = (
   value: bigint,
   client?: PublicClient,
   account?: Address,
+  creatorAddress?: Address,
 ) => {
   switch (actionType) {
     case ActionType.Mint:
@@ -158,6 +159,7 @@ export const getTxSimulation = (
           value,
           account,
           client,
+          creatorAddress,
         )
       } else {
         throw new PluginActionNotImplementedError()

--- a/packages/utils/src/types/actions.ts
+++ b/packages/utils/src/types/actions.ts
@@ -465,6 +465,7 @@ export interface IActionPlugin {
     value: bigint,
     account?: Address,
     client?: PublicClient,
+    creatorAddress?: Address,
   ) => Promise<SimulateContractReturnType>
   getProjectFees?: (params: ActionParams) => Promise<bigint>
   getFees?: (


### PR DESCRIPTION
Adds a `creatorAddress` parameter to the `simulateMint` function.


This will be used in the simulateMint function as a referral address where applicable.


Related PRs:

- Sound Plugin: https://github.com/rabbitholegg/questdk-plugins/pull/436

