### PR TITLE
feat(sound): use `creatorAddress` as referral 

### DIFF
--- a/.changeset/mighty-pianos-exercise.md
+++ b/.changeset/mighty-pianos-exercise.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-soundxyz": minor
+---
+
+use boost creator as referral

--- a/packages/soundxyz/src/Soundxyz.ts
+++ b/packages/soundxyz/src/Soundxyz.ts
@@ -7,6 +7,7 @@ import {
   SUPERMINTER_V2_ABI,
   TOTAL_PRICE_AND_FEES_V1_ABI,
   TOTAL_PRICE_AND_FEES_V2_ABI,
+  ZORA_DEPLOYER_ADDRESS,
 } from './constants'
 import type { TotalPriceAndFees } from './types'
 import { Chains } from './utils'
@@ -99,6 +100,7 @@ export const simulateMint = async (
   value: bigint,
   account?: Address,
   client?: PublicClient,
+  creatorAddress?: Address,
 ): Promise<SimulateContractReturnType> => {
   const { contractAddress, recipient, tokenId, amount } = mint
   const _client = (client ??
@@ -128,7 +130,7 @@ export const simulateMint = async (
     signedClaimTicket: 0,
     signedDeadline: 0,
     signature: zeroHash,
-    affiliate: zeroAddress,
+    affiliate: creatorAddress ?? ZORA_DEPLOYER_ADDRESS,
     affiliateProof: [zeroHash],
     attributionId: 0,
   }

--- a/packages/soundxyz/src/constants.ts
+++ b/packages/soundxyz/src/constants.ts
@@ -316,3 +316,7 @@ export const MINT_INFO_LIST_ABI = [
     type: 'function',
   },
 ]
+
+// for referrals
+export const ZORA_DEPLOYER_ADDRESS =
+  '0xe3bBA2A4F8E0F5C32EF5097F988a4d88075C8B48'


### PR DESCRIPTION
- Use boost `creatorAddress` as dynamic referral address for embedded mints.

- Use ZORA deployer address as a fallback if no creatorAddress is found