### PR TITLE
refactor(foundation): disable dutch-auction fee mechanism

### DIFF
--- a/.changeset/poor-dragons-scream.md
+++ b/.changeset/poor-dragons-scream.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-foundation": patch
+---
+
+disable dutch auction type mints (foundation)

--- a/packages/foundation/src/Foundation.ts
+++ b/packages/foundation/src/Foundation.ts
@@ -313,15 +313,9 @@ export const simulateMint = async (
       contractAddress,
     )
     if (dutchAuctionSeller && dutchAuctionSeller !== zeroAddress) {
-      const result = await _client.simulateContract({
-        address: dropFactoryAddress,
-        value,
-        abi: [DUTCH_AUCTION_FRAGMENT],
-        functionName: 'mintFromDutchAuctionV2',
-        args: [contractAddress, mintAmount, recipient],
-        account: account || DEFAULT_ACCOUNT,
-      })
-      return result
+      // Not supported due to the way we calculate fees.
+      // https://github.com/rabbitholegg/questdk-plugins/pull/445#pullrequestreview-2111167218
+      throw new Error('Dutch auction is not supported')
     }
 
     throw new Error('Invalid mint arguments')


### PR DESCRIPTION
The dutch auction mechanism that is used by foundation will not be compatible, as if the price changes it will no longer be able to pass simulations as we record the fee at boost creation.

https://github.com/rabbitholegg/questdk-plugins/pull/445#issuecomment-2161740068