### PR TITLE
feat: Add getExternalUrl function to IActionPlugin

### DIFF
--- a/.changeset/kind-doors-sort.md
+++ b/.changeset/kind-doors-sort.md
@@ -1,0 +1,6 @@
+---
+"@rabbitholegg/questdk-plugin-registry": minor
+"@rabbitholegg/questdk-plugin-utils": minor
+---
+
+add `getExternalUrl` funciton to IActionPlugin

--- a/.changeset/kind-doors-sort.md
+++ b/.changeset/kind-doors-sort.md
@@ -3,4 +3,4 @@
 "@rabbitholegg/questdk-plugin-utils": minor
 ---
 
-add `getExternalUrl` funciton to IActionPlugin
+add `getExternalUrl` function to IActionPlugin

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -209,6 +209,17 @@ export const getFees = (
   }
 }
 
+export const getExternalUrl = (
+  plugin: IActionPlugin,
+  params: ActionParams,
+) => {
+  if (typeof plugin.getExternalUrl === 'function') {
+    return plugin.getExternalUrl(params)
+  } else {
+    throw new PluginActionNotImplementedError()
+  }
+}
+
 export const canValidate = (plugin: IActionPlugin, actionType: ActionType) => {
   switch (actionType) {
     case ActionType.Follow:

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -209,10 +209,7 @@ export const getFees = (
   }
 }
 
-export const getExternalUrl = (
-  plugin: IActionPlugin,
-  params: ActionParams,
-) => {
+export const getExternalUrl = (plugin: IActionPlugin, params: ActionParams) => {
   if (typeof plugin.getExternalUrl === 'function') {
     return plugin.getExternalUrl(params)
   } else {

--- a/packages/utils/src/types/actions.ts
+++ b/packages/utils/src/types/actions.ts
@@ -539,6 +539,7 @@ export interface IActionPlugin {
   getFees?: (
     params: ActionParams,
   ) => Promise<{ actionFee: bigint; projectFee: bigint }>
+  getExternalUrl?: (params: ActionParams) => Promise<string>
   validate?: (
     validationPayload: PluginActionValidation,
   ) =>


### PR DESCRIPTION
- adds a `getExternalUrl` function which will (optionally) be used to generate an external url for a plugin. The Url will be generated on boost creation (w/referral atttached) instead of on the fly.


Fixes BOOST-4250