### PR TITLE
feat(utils): allow referral to be optional in `MintIntentParams`

### DIFF
--- a/.changeset/silent-fireants-grab.md
+++ b/.changeset/silent-fireants-grab.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-utils": minor
+---
+
+allow referral to be optional in MintIntentParams

--- a/packages/utils/src/types/intents.ts
+++ b/packages/utils/src/types/intents.ts
@@ -1,8 +1,9 @@
 import type { MintActionParams } from './actions'
 export type MintIntentParams = Required<
-  Omit<MintActionParams, 'amount' | 'tokenId'>
+  Omit<MintActionParams, 'amount' | 'tokenId' | 'referral'>
 > & {
   amount: bigint
   tokenId?: number
+  referral?: string
 }
 export type IntentParams = MintIntentParams

--- a/packages/utils/src/types/intents.ts
+++ b/packages/utils/src/types/intents.ts
@@ -1,9 +1,10 @@
 import type { MintActionParams } from './actions'
+import type { Address } from 'viem'
 export type MintIntentParams = Required<
   Omit<MintActionParams, 'amount' | 'tokenId' | 'referral'>
 > & {
   amount: bigint
   tokenId?: number
-  referral?: string
+  referral?: Address
 }
 export type IntentParams = MintIntentParams


### PR DESCRIPTION
Referral will not be used in every situation and MintIntentParams gives a type error if it is not present. Some plugins do not have a referral program, so the referral will not be used int his scenario.

This PR makes the referral param optional in the MintIntentParams type

