### PR TITLE
fix(zora): change bytecode retrieval method

### DIFF
--- a/.changeset/tame-rabbits-provide.md
+++ b/.changeset/tame-rabbits-provide.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-zora": patch
+---
+
+change bytecode retrieval method (zora)

--- a/packages/zora/src/Zora.ts
+++ b/packages/zora/src/Zora.ts
@@ -274,7 +274,8 @@ export const simulateMint = async (
   )}`
 
   // Check if the implementation contracts bytecode contains valid function selectors
-  const bytecode = await _client.getCode({ address: implementationAddress })
+  const bytecode = await _client.getBytecode({ address: implementationAddress })
+
   const containsSelector = FUNCTION_SELECTORS.some((selector) =>
     bytecode?.includes(selector),
   )


### PR DESCRIPTION
The `getCode` method is producing errors during simulation, so we are reverting to the previous getBytecode method.