### PR TITLE
feat: add actionType to getExternalUrl

### DIFF
--- a/.changeset/beige-rats-reflect.md
+++ b/.changeset/beige-rats-reflect.md
@@ -1,4 +1,5 @@
 ---
+"@rabbitholegg/questdk-plugin-registry": minor
 "@rabbitholegg/questdk-plugin-titles": minor
 "@rabbitholegg/questdk-plugin-utils": minor
 "@rabbitholegg/questdk-plugin-zora": minor

--- a/.changeset/beige-rats-reflect.md
+++ b/.changeset/beige-rats-reflect.md
@@ -1,0 +1,7 @@
+---
+"@rabbitholegg/questdk-plugin-titles": minor
+"@rabbitholegg/questdk-plugin-utils": minor
+"@rabbitholegg/questdk-plugin-zora": minor
+---
+
+add optional actionType to getExternalUrl

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -209,9 +209,13 @@ export const getFees = (
   }
 }
 
-export const getExternalUrl = (plugin: IActionPlugin, params: ActionParams) => {
+export const getExternalUrl = (
+  plugin: IActionPlugin,
+  params: ActionParams,
+  actionType?: ActionType,
+) => {
   if (typeof plugin.getExternalUrl === 'function') {
-    return plugin.getExternalUrl(params)
+    return plugin.getExternalUrl(params, actionType)
   } else {
     throw new PluginActionNotImplementedError()
   }

--- a/packages/titles/src/Titles.test.ts
+++ b/packages/titles/src/Titles.test.ts
@@ -14,6 +14,7 @@ import {
 } from './test-transactions'
 import { apply } from '@rabbitholegg/questdk'
 import {
+  ActionType,
   Chains,
   type MintIntentParams,
 } from '@rabbitholegg/questdk-plugin-utils'
@@ -184,14 +185,23 @@ describe('simulateMint function', () => {
 })
 
 describe('getExternalUrl function', () => {
-  test('should return the correct URL for a V2 mint', () => {
-    const url = getExternalUrl({
+  test('should return the correct URL for a V2 mint', async () => {
+    const url = await getExternalUrl({
       chainId: Chains.BASE,
       contractAddress: '0x432f4ccc39ab8dd8015f590a56244becb8d16933',
       tokenId: 1,
-    })
+    }, ActionType.Mint)
     expect(url).toEqual(
       'https://titles.xyz/collect/base/0x432f4ccc39ab8dd8015f590a56244becb8d16933/1',
+    )
+  })
+
+  test('should return the correct URL for a create action', async () => {
+    const url = await getExternalUrl({
+      chainId: Chains.BASE,
+    }, ActionType.Create)
+    expect(url).toEqual(
+      'https://titles.xyz/create',
     )
   })
 })

--- a/packages/titles/src/Titles.test.ts
+++ b/packages/titles/src/Titles.test.ts
@@ -186,23 +186,27 @@ describe('simulateMint function', () => {
 
 describe('getExternalUrl function', () => {
   test('should return the correct URL for a V2 mint', async () => {
-    const url = await getExternalUrl({
-      chainId: Chains.BASE,
-      contractAddress: '0x432f4ccc39ab8dd8015f590a56244becb8d16933',
-      tokenId: 1,
-    }, ActionType.Mint)
+    const url = await getExternalUrl(
+      {
+        chainId: Chains.BASE,
+        contractAddress: '0x432f4ccc39ab8dd8015f590a56244becb8d16933',
+        tokenId: 1,
+      },
+      ActionType.Mint,
+    )
     expect(url).toEqual(
       'https://titles.xyz/collect/base/0x432f4ccc39ab8dd8015f590a56244becb8d16933/1',
     )
   })
 
   test('should return the correct URL for a create action', async () => {
-    const url = await getExternalUrl({
-      chainId: Chains.BASE,
-    }, ActionType.Create)
-    expect(url).toEqual(
-      'https://titles.xyz/create',
+    const url = await getExternalUrl(
+      {
+        chainId: Chains.BASE,
+      },
+      ActionType.Create,
     )
+    expect(url).toEqual('https://titles.xyz/create')
   })
 })
 

--- a/packages/titles/src/Titles.ts
+++ b/packages/titles/src/Titles.ts
@@ -12,6 +12,8 @@ import {
   compressJson,
 } from '@rabbitholegg/questdk'
 import {
+  ActionParams,
+  ActionType,
   Chains,
   DEFAULT_ACCOUNT,
   DEFAULT_REFERRAL,
@@ -164,14 +166,23 @@ export const simulateMint = async (
   return result
 }
 
-export function getExternalUrl(params: MintActionParams): string {
-  const { chainId, contractAddress, tokenId } = params
-  const slug = CHAIN_ID_TO_SLUG[chainId]
+export async function getExternalUrl(params: ActionParams, actionType?: ActionType) {
 
-  if (!slug || !contractAddress || !tokenId) {
-    return 'https://titles.xyz'
+  if (actionType === ActionType.Mint) {
+    const { chainId, contractAddress, tokenId } = params as MintActionParams
+    const slug = CHAIN_ID_TO_SLUG[chainId]
+  
+    if (!slug || !contractAddress || !tokenId) {
+      return 'https://titles.xyz'
+    }
+    return `https://titles.xyz/collect/${slug}/${contractAddress}/${tokenId}`
   }
-  return `https://titles.xyz/collect/${slug}/${contractAddress}/${tokenId}`
+
+  if (actionType === ActionType.Create) {
+    return 'https://titles.xyz/create'
+  }
+
+  return 'https://titles.xyz'
 }
 
 export const getSupportedTokenAddresses = async (

--- a/packages/titles/src/Titles.ts
+++ b/packages/titles/src/Titles.ts
@@ -166,12 +166,14 @@ export const simulateMint = async (
   return result
 }
 
-export async function getExternalUrl(params: ActionParams, actionType?: ActionType) {
-
+export async function getExternalUrl(
+  params: ActionParams,
+  actionType?: ActionType,
+) {
   if (actionType === ActionType.Mint) {
     const { chainId, contractAddress, tokenId } = params as MintActionParams
     const slug = CHAIN_ID_TO_SLUG[chainId]
-  
+
     if (!slug || !contractAddress || !tokenId) {
       return 'https://titles.xyz'
     }

--- a/packages/titles/src/index.ts
+++ b/packages/titles/src/index.ts
@@ -24,8 +24,7 @@ export const Titles: IActionPlugin = {
   getMintIntent,
   mint,
   simulateMint,
-  getExternalUrl: async (params: ActionParams) =>
-    getExternalUrl(params as unknown as MintActionParams),
+  getExternalUrl,
   getProjectFees: async (params: ActionParams) =>
     getProjectFees(params as unknown as MintActionParams),
   getFees: async (params: ActionParams) =>

--- a/packages/utils/src/types/actions.ts
+++ b/packages/utils/src/types/actions.ts
@@ -539,7 +539,7 @@ export interface IActionPlugin {
   getFees?: (
     params: ActionParams,
   ) => Promise<{ actionFee: bigint; projectFee: bigint }>
-  getExternalUrl?: (params: ActionParams) => Promise<string>
+  getExternalUrl?: (params: ActionParams, actionType?: ActionType) => Promise<string>
   validate?: (
     validationPayload: PluginActionValidation,
   ) =>

--- a/packages/utils/src/types/actions.ts
+++ b/packages/utils/src/types/actions.ts
@@ -539,7 +539,10 @@ export interface IActionPlugin {
   getFees?: (
     params: ActionParams,
   ) => Promise<{ actionFee: bigint; projectFee: bigint }>
-  getExternalUrl?: (params: ActionParams, actionType?: ActionType) => Promise<string>
+  getExternalUrl?: (
+    params: ActionParams,
+    actionType?: ActionType,
+  ) => Promise<string>
   validate?: (
     validationPayload: PluginActionValidation,
   ) =>

--- a/packages/zora/src/Zora.test.ts
+++ b/packages/zora/src/Zora.test.ts
@@ -528,7 +528,7 @@ describe('getExternalUrl function', () => {
       tokenId: 1,
       referral: getAddress('0x1234567890123456789012345678901234567890'),
     }
-    const result = await getExternalUrl(params)
+    const result = await getExternalUrl(params, ActionType.Mint)
     expect(result).toBe(
       'https://zora.co/collect/zora:0x393c46fe7887697124A73f6028f39751aA1961a3/1?referrer=0x1234567890123456789012345678901234567890',
     )
@@ -540,7 +540,7 @@ describe('getExternalUrl function', () => {
       contractAddress: getAddress('0x393c46fe7887697124a73f6028f39751aa1961a3'),
       tokenId: 1,
     }
-    const result = await getExternalUrl(params)
+    const result = await getExternalUrl(params, ActionType.Mint)
     expect(result).toBe(
       `https://zora.co/collect/zora:0x393c46fe7887697124A73f6028f39751aA1961a3/1?referrer=${ZORA_DEPLOYER_ADDRESS}`,
     )
@@ -552,7 +552,7 @@ describe('getExternalUrl function', () => {
       contractAddress: getAddress('0x393c46fe7887697124a73f6028f39751aa1961a3'),
       referral: getAddress('0x1234567890123456789012345678901234567890'),
     }
-    const result = await getExternalUrl(params)
+    const result = await getExternalUrl(params, ActionType.Mint)
     expect(result).toBe(
       'https://zora.co/collect/zora:0x393c46fe7887697124A73f6028f39751aA1961a3?referrer=0x1234567890123456789012345678901234567890',
     )
@@ -565,9 +565,17 @@ describe('getExternalUrl function', () => {
       tokenId: 39,
       referral: getAddress('0xe3bBA2A4F8E0F5C32EF5097F988a4d88075C8B48'),
     }
-    const result = await getExternalUrl(params)
+    const result = await getExternalUrl(params, ActionType.Mint)
     expect(result).toBe(
       'https://testnet.zora.co/collect/bsep:0x627a509D76498DDD7D80a28eF4cD887B5b6df2Cd/39?referrer=0xe3bBA2A4F8E0F5C32EF5097F988a4d88075C8B48',
     )
+  })
+
+  test('should return correct url for create', async () => {
+    const params = {
+      chainId: Chains.ZORA,
+    }
+    const result = await getExternalUrl(params, ActionType.Create)
+    expect(result).toBe('https://zora.co/create')
   })
 })

--- a/packages/zora/src/Zora.ts
+++ b/packages/zora/src/Zora.ts
@@ -19,7 +19,7 @@ import {
   type TransactionFilter,
   compressJson,
 } from '@rabbitholegg/questdk'
-import { formatAmountToFilterOperator } from '@rabbitholegg/questdk-plugin-utils'
+import { ActionParams, formatAmountToFilterOperator } from '@rabbitholegg/questdk-plugin-utils'
 import {
   ActionType,
   Chains,
@@ -443,21 +443,29 @@ export const getDynamicNameParams = async (
 }
 
 export const getExternalUrl = async (
-  params: MintActionParams,
+  params: ActionParams,
+  actionType?: ActionType,
 ): Promise<string> => {
-  const { chainId, contractAddress, tokenId, referral } = params
-  const chainSlug = CHAIN_ID_TO_ZORA_SLUG[chainId]
-  const isTestnet =
-    chainId === Chains.BASE_SEPOLIA || chainId === Chains.SEPOLIA
 
-  if (chainSlug) {
-    const referralParams = `?referrer=${referral ?? ZORA_DEPLOYER_ADDRESS}`
-    const domain = isTestnet ? 'testnet.zora.co' : 'zora.co'
-    const baseUrl = `https://${domain}/collect/${chainSlug}:${contractAddress}`
+  if (actionType === ActionType.Mint) {
+    const { chainId, contractAddress, tokenId, referral } = params as MintActionParams
+    const chainSlug = CHAIN_ID_TO_ZORA_SLUG[chainId]
+    const isTestnet =
+      chainId === Chains.BASE_SEPOLIA || chainId === Chains.SEPOLIA
+  
+    if (chainSlug) {
+      const referralParams = `?referrer=${referral ?? ZORA_DEPLOYER_ADDRESS}`
+      const domain = isTestnet ? 'testnet.zora.co' : 'zora.co'
+      const baseUrl = `https://${domain}/collect/${chainSlug}:${contractAddress}`
+  
+      return tokenId != null
+        ? `${baseUrl}/${tokenId}${referralParams}`
+        : `${baseUrl}${referralParams}`
+    }
+  }
 
-    return tokenId != null
-      ? `${baseUrl}/${tokenId}${referralParams}`
-      : `${baseUrl}${referralParams}`
+  if (actionType === ActionType.Create) {
+    return 'https://zora.co/create'
   }
 
   // fallback to default zora url

--- a/packages/zora/src/Zora.ts
+++ b/packages/zora/src/Zora.ts
@@ -19,7 +19,10 @@ import {
   type TransactionFilter,
   compressJson,
 } from '@rabbitholegg/questdk'
-import { ActionParams, formatAmountToFilterOperator } from '@rabbitholegg/questdk-plugin-utils'
+import {
+  ActionParams,
+  formatAmountToFilterOperator,
+} from '@rabbitholegg/questdk-plugin-utils'
 import {
   ActionType,
   Chains,
@@ -446,18 +449,18 @@ export const getExternalUrl = async (
   params: ActionParams,
   actionType?: ActionType,
 ): Promise<string> => {
-
   if (actionType === ActionType.Mint) {
-    const { chainId, contractAddress, tokenId, referral } = params as MintActionParams
+    const { chainId, contractAddress, tokenId, referral } =
+      params as MintActionParams
     const chainSlug = CHAIN_ID_TO_ZORA_SLUG[chainId]
     const isTestnet =
       chainId === Chains.BASE_SEPOLIA || chainId === Chains.SEPOLIA
-  
+
     if (chainSlug) {
       const referralParams = `?referrer=${referral ?? ZORA_DEPLOYER_ADDRESS}`
       const domain = isTestnet ? 'testnet.zora.co' : 'zora.co'
       const baseUrl = `https://${domain}/collect/${chainSlug}:${contractAddress}`
-  
+
       return tokenId != null
         ? `${baseUrl}/${tokenId}${referralParams}`
         : `${baseUrl}${referralParams}`

--- a/packages/zora/src/index.ts
+++ b/packages/zora/src/index.ts
@@ -29,8 +29,7 @@ export const Zora: IActionPlugin = {
   swap: async () => new PluginActionNotImplementedError(),
   mint,
   getDynamicNameParams,
-  getExternalUrl: async (params: ActionParams) =>
-    getExternalUrl(params as unknown as MintActionParams),
+  getExternalUrl,
   getProjectFees: async (params: ActionParams) =>
     getProjectFees(params as unknown as MintActionParams),
   getFees: async (params: ActionParams) =>


### PR DESCRIPTION
Some projects use multiple actionTypes, and we need a way to derive a different external url based on the actionType passed in.

Only projects needed change are Zora (Create/Mint) and TITLES (Create/Mint)

These changes will also make it easier in the future to add custom external links for defi projects which have mutiple action types available.

BOOST-4345

https://linear.app/rh-app/issue/BOOST-4345/update-externalurl-to-include-actiontype