### PR TITLE
feat(utils): upgrade mint action params to support more numerical types, and operators

### DIFF
--- a/.changeset/ninety-stingrays-destroy.md
+++ b/.changeset/ninety-stingrays-destroy.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-utils": minor
+---
+
+Upgrade Mint action schema to support numeric operator types

--- a/packages/utils/src/types/actions.ts
+++ b/packages/utils/src/types/actions.ts
@@ -55,7 +55,7 @@ export type MintActionParams = {
   chainId: number
   contractAddress: Address
   tokenId?: number
-  amount?: number | FilterOperator
+  amount?: number | string | bigint | FilterOperator
   recipient?: Address
   referral?: Address
 }
@@ -215,11 +215,30 @@ export const MintActionFormSchema = z.object({
   amountOperator: QuestInputActionParamsAmountOperatorEnum.optional(),
 })
 
+export const NumericSchema = z.union([z.bigint(), z.string(), z.number()])
+export const AmountSchema = z.union([
+  z.bigint(),
+  z.number(),
+  z.string(),
+  z.object({
+    $gt: NumericSchema.optional(),
+  }),
+  z.object({
+    $gte: NumericSchema.optional(),
+  }),
+  z.object({
+    $lt: NumericSchema.optional(),
+  }),
+  z.object({
+    $lte: NumericSchema.optional(),
+  }),
+])
+
 export const MintActionDetailSchema = z.object({
   chainId: z.number(),
   contractAddress: EthAddressSchema,
   tokenId: z.number().optional(),
-  amount: z.string().optional(),
+  amount: AmountSchema,
   amountOperator: QuestInputActionParamsAmountOperatorEnum.optional(),
 })
 

--- a/packages/utils/src/types/filters.ts
+++ b/packages/utils/src/types/filters.ts
@@ -27,16 +27,16 @@ export type NumericOperator =
   | number
   | string
   | {
-      $gt?: bigint
+      $gt?: bigint | string | number;
     }
   | {
-      $gte?: bigint
+      $gte?: bigint | string | number;
     }
   | {
-      $lt?: bigint
+      $lt?: bigint | string | number;
     }
   | {
-      $lte?: bigint
+      $lte?: bigint | string | number;
     }
 
 export type StringOperator = {

--- a/packages/utils/src/types/filters.ts
+++ b/packages/utils/src/types/filters.ts
@@ -27,16 +27,16 @@ export type NumericOperator =
   | number
   | string
   | {
-      $gt?: bigint | string | number;
+      $gt?: bigint | string | number
     }
   | {
-      $gte?: bigint | string | number;
+      $gte?: bigint | string | number
     }
   | {
-      $lt?: bigint | string | number;
+      $lt?: bigint | string | number
     }
   | {
-      $lte?: bigint | string | number;
+      $lte?: bigint | string | number
     }
 
 export type StringOperator = {


### PR DESCRIPTION
on demand validation is failing when the mint action amount is an operator instead of a numeric string.

this work expands the acceptable types to handle more cases, implementing a zod schema for numeric operators