### PR TITLE
fix(zora): add tokenId to zora SDK getToken call for 1155s

### DIFF
--- a/.changeset/slow-peas-sit.md
+++ b/.changeset/slow-peas-sit.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-zora": patch
+---
+
+add tokenId to zora SDK call for 1155s

--- a/packages/zora/src/Zora.test.ts
+++ b/packages/zora/src/Zora.test.ts
@@ -2,7 +2,6 @@ import {
   create,
   getDynamicNameParams,
   getExternalUrl,
-  getFees,
   mint,
   simulateMint,
 } from './Zora'

--- a/packages/zora/src/Zora.test.ts
+++ b/packages/zora/src/Zora.test.ts
@@ -2,6 +2,7 @@ import {
   create,
   getDynamicNameParams,
   getExternalUrl,
+  getFees,
   mint,
   simulateMint,
 } from './Zora'
@@ -384,6 +385,32 @@ describe('Given the getFee function', () => {
     expect(getFeesSpy.mock.calls.length).toBe(1)
     expect(fee.projectFee).equals(BigInt('777000000000000'))
     expect(fee.actionFee).equals(BigInt('0'))
+  })
+
+  test('should return the correct project + action fee for V1 1155 mint w/o tokenId', async () => {
+    const contractAddress: Address =
+      '0x34ce43d58d0d4ecf2581f4eb6238178c77fb32d9'
+    const tokenId = undefined
+    const mintParams = {
+      contractAddress,
+      tokenId,
+      chainId: Chains.OPTIMISM,
+      amount: 1,
+    }
+
+    const mockFns = {
+      getFees: async (_mint: MintActionParams) => ({
+        projectFee: parseEther('0.000777'),
+        actionFee: parseEther('0.29'),
+      }),
+    }
+
+    const getFeesSpy = vi.spyOn(mockFns, 'getFees')
+    const fee = await mockFns.getFees(mintParams)
+    console.log('fee', fee)
+    expect(getFeesSpy.mock.calls.length).toBe(1)
+    expect(fee.projectFee).equals(parseEther('0.000777'))
+    expect(fee.actionFee).equals(parseEther('0.29'))
   })
 })
 

--- a/packages/zora/src/Zora.test.ts
+++ b/packages/zora/src/Zora.test.ts
@@ -407,7 +407,6 @@ describe('Given the getFee function', () => {
 
     const getFeesSpy = vi.spyOn(mockFns, 'getFees')
     const fee = await mockFns.getFees(mintParams)
-    console.log('fee', fee)
     expect(getFeesSpy.mock.calls.length).toBe(1)
     expect(fee.projectFee).equals(parseEther('0.000777'))
     expect(fee.actionFee).equals(parseEther('0.29'))

--- a/packages/zora/src/Zora.ts
+++ b/packages/zora/src/Zora.ts
@@ -456,7 +456,8 @@ export const getFees = async (
   mint: MintActionParams,
 ): Promise<{ actionFee: bigint; projectFee: bigint }> => {
   try {
-    const { chainId, contractAddress, tokenId, amount } = mint
+    const { chainId, contractAddress, amount } = mint
+    let tokenId = mint.tokenId
 
     const client = getPublicClient(chainId)
 
@@ -470,6 +471,12 @@ export const getFees = async (
       chainId,
       publicClient: client,
     })
+
+    // if contract type is 1155, we need to get the latest tokenId
+    if (contractType === '1155' && tokenId == null) {
+      const nextTokenId = await getNextTokenId(client, contractAddress)
+      tokenId = Number(nextTokenId)
+    }
 
     const quantityToMint = formatAmountToInteger(amount)
     const { prepareMint } = await collectorClient.getToken({

--- a/packages/zora/src/Zora.ts
+++ b/packages/zora/src/Zora.ts
@@ -472,7 +472,6 @@ export const getFees = async (
       publicClient: client,
     })
 
-    // if contract type is 1155, we need to get the latest tokenId
     if (contractType === '1155' && tokenId == null) {
       const nextTokenId = await getNextTokenId(client, contractAddress)
       tokenId = Number(nextTokenId)

--- a/packages/zora/src/Zora.ts
+++ b/packages/zora/src/Zora.ts
@@ -472,6 +472,7 @@ export const getFees = async (
       publicClient: client,
     })
 
+    // if no tokenId is provided for 1155, we need to get the latest tokenId
     if (contractType === '1155' && tokenId == null) {
       const nextTokenId = await getNextTokenId(client, contractAddress)
       tokenId = Number(nextTokenId)


### PR DESCRIPTION
- Updated Zora SDK requires a tokenId on the `getToken` call, otherwise it will fail and return the base fee.

Fixes BOOST-4477

https://linear.app/rh-app/issue/BOOST-4477/zora-getfees-fails-for-1155-wo-tokenid-plugin