### PR TITLE
fix(titles): fix failing simulate mint test

### DIFF
--- a/.changeset/moody-moose-shop.md
+++ b/.changeset/moody-moose-shop.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-titles": patch
+---
+
+fix failing tests for titles simulateMint

--- a/packages/titles/src/Titles.test.ts
+++ b/packages/titles/src/Titles.test.ts
@@ -154,7 +154,7 @@ describe('simulateMint function', () => {
     )
 
     const request = result.request
-    expect(request.address).toBe('0x432f4Ccc39AB8DD8015F590a56244bECb8D16933')
+    expect(request.address).toBe('0xc1eee0e85cf2356357ccad2cd1a60a5935538e4d')
     expect(request.functionName).toBe('mint')
     expect(request.value).toBe(value)
   })

--- a/packages/titles/src/Titles.test.ts
+++ b/packages/titles/src/Titles.test.ts
@@ -137,11 +137,11 @@ describe('Given the getFee function', () => {
 describe('simulateMint function', () => {
   test('should simulate a V2 mint', async () => {
     const contractAddress: Address =
-      '0x432f4Ccc39AB8DD8015F590a56244bECb8D16933'
+      '0xc1eee0e85cf2356357ccad2cd1a60a5935538e4d'
     const mintParams = {
       contractAddress,
-      chainId: Chains.BASE,
-      tokenId: 4,
+      chainId: Chains.ZORA,
+      tokenId: 1,
       recipient: '0xf70da97812CB96acDF810712Aa562db8dfA3dbEF',
     }
     const value = parseEther('0.0005')
@@ -155,30 +155,6 @@ describe('simulateMint function', () => {
 
     const request = result.request
     expect(request.address).toBe('0x432f4Ccc39AB8DD8015F590a56244bECb8D16933')
-    expect(request.functionName).toBe('mint')
-    expect(request.value).toBe(value)
-  })
-
-  test('should simulate a V2 mint', async () => {
-    const contractAddress: Address =
-      '0x06d7D870a41a44B5b7eBF46019bD5f8487362de3'
-    const mintParams = {
-      contractAddress,
-      chainId: Chains.BASE,
-      tokenId: 5,
-      recipient: '0xf70da97812CB96acDF810712Aa562db8dfA3dbEF',
-    }
-    const value = parseEther('0.0005')
-    const address = mintParams.recipient as Address
-
-    const result = await simulateMint(
-      mintParams as MintIntentParams,
-      value,
-      address,
-    )
-
-    const request = result.request
-    expect(request.address).toBe('0x06d7D870a41a44B5b7eBF46019bD5f8487362de3')
     expect(request.functionName).toBe('mint')
     expect(request.value).toBe(value)
   })


### PR DESCRIPTION
Test is failing due to the target NFT not being mintable.

Switched the test to one that targets an NFT that is open indefinitely.

https://linear.app/rh-app/issue/BOOST-4478/fixtitles-fix-failing-simulate-mint-test

Fixes BOOST-4478