### PR TITLE
[BOOST-4470] Further expand filter interfaces, schemas

### DIFF
--- a/.changeset/dry-ducks-sleep.md
+++ b/.changeset/dry-ducks-sleep.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-utils": minor
+---
+
+allow any combination of filters in mint params

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,3 +1,4 @@
+
 export {
   CHAIN_TO_TOKENS,
   Chains,
@@ -93,6 +94,7 @@ export type {
   PremintValidationParams,
   PremintActionDetail,
   PremintActionForm,
+  Primitive,
 } from './types'
 
 export {
@@ -141,6 +143,7 @@ export {
   PremintActionDetailSchema,
   PremintActionFormSchema,
   // Filter Schemas
+  // Primitive,
   NumericSchema,
   NumericOperatorSchema,
   BitmaskFilterSchema,

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -143,7 +143,6 @@ export {
   PremintActionDetailSchema,
   PremintActionFormSchema,
   // Filter Schemas
-  // Primitive,
   NumericSchema,
   NumericOperatorSchema,
   BitmaskFilterSchema,

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,4 +1,3 @@
-
 export {
   CHAIN_TO_TOKENS,
   Chains,

--- a/packages/utils/src/types/actions.ts
+++ b/packages/utils/src/types/actions.ts
@@ -1,20 +1,19 @@
+import { UUID } from 'crypto'
 import {
-  type PublicClient,
   type Address,
+  type PublicClient,
   type SimulateContractReturnType,
   type TransactionRequest,
 } from 'viem'
-import {
-  FilterOperatorSchema,
-  NumericSchema,
-  type FilterOperator,
-  type TransactionFilter,
-} from './filters'
-import { PluginActionNotImplementedError } from '../errors'
-import type { MintIntentParams } from './intents'
 import { ZodSchema, z } from 'zod'
+import { PluginActionNotImplementedError } from '../errors'
 import { EthAddressSchema } from './common'
-import { UUID } from 'crypto'
+import {
+  FilterSchema,
+  type FilterOperator,
+  type TransactionFilter
+} from './filters'
+import type { MintIntentParams } from './intents'
 import { QuestCompletionPayload } from './quests'
 
 export type SwapActionParams = {
@@ -216,7 +215,7 @@ export const StakeActionFormSchema = BaseStakeActionFormaSchema
 export const MintActionFormSchema = z.object({
   contractAddress: EthAddressSchema,
   tokenId: z.number().optional(),
-  amount: z.union([NumericSchema, FilterOperatorSchema]),
+  amount: FilterSchema,
   amountOperator: QuestInputActionParamsAmountOperatorEnum.optional(),
 })
 
@@ -224,7 +223,7 @@ export const MintActionDetailSchema = z.object({
   chainId: z.number(),
   contractAddress: EthAddressSchema,
   tokenId: z.number().optional(),
-  amount: z.union([NumericSchema, FilterOperatorSchema]),
+  amount: FilterSchema,
   amountOperator: QuestInputActionParamsAmountOperatorEnum.optional(),
 })
 

--- a/packages/utils/src/types/actions.ts
+++ b/packages/utils/src/types/actions.ts
@@ -11,7 +11,7 @@ import { EthAddressSchema } from './common'
 import {
   FilterSchema,
   type FilterOperator,
-  type TransactionFilter
+  type TransactionFilter,
 } from './filters'
 import type { MintIntentParams } from './intents'
 import { QuestCompletionPayload } from './quests'

--- a/packages/utils/src/types/filters.ts
+++ b/packages/utils/src/types/filters.ts
@@ -129,7 +129,7 @@ export const TransactionFilterSchema: z.ZodType<TransactionFilter> = z.record(
   z.lazy(() => FilterSchema),
 )
 
-type Primitive = string | number | boolean | bigint
+export type Primitive = string | number | boolean | bigint
 export const PrimitiveSchema = z.union([z.string(), z.number(), z.boolean(), z.bigint()])
 
 export type FilterObject = {

--- a/packages/utils/src/types/filters.ts
+++ b/packages/utils/src/types/filters.ts
@@ -66,13 +66,13 @@ export type FilterOperator =
 
 export type ArrayOperator =
   | {
-      $some?: FilterOperator[]
+      $some?: Filter[]
     }
   | {
-      $first?: FilterOperator
+      $first?: Filter
     }
   | {
-      $last?: FilterOperator
+      $last?: Filter
     }
   | {
       $nth?: NthFilter
@@ -81,33 +81,33 @@ export type ArrayOperator =
 export const ArrayOperatorSchema: z.ZodType<ArrayOperator> = z.union([
   z.object({
     $some: z
-      .lazy(() => FilterOperatorSchema)
+      .lazy(() => FilterSchema)
       .array()
       .optional(),
   }),
-  z.object({ $first: z.lazy(() => FilterOperatorSchema).optional() }),
-  z.object({ $last: z.lazy(() => FilterOperatorSchema).optional() }),
-  z.object({ $nth: z.lazy(() => NthFilterSchema).optional() }),
+  z.object({ $first: z.lazy(() => FilterSchema).optional() }),
+  z.object({ $last: z.lazy(() => FilterSchema).optional() }),
+  z.object({ $nth: z.lazy(() => FilterSchema).optional() }),
 ])
 
 export type LogicalOperator =
   | {
-      $and?: FilterOperator[]
+      $and?: Filter[]
     }
   | {
-      $or?: FilterOperator[]
+      $or?: Filter[]
     }
 
 export const LogicalOperatorSchema: z.ZodType<LogicalOperator> = z.union([
   z.object({
     $and: z
-      .lazy(() => FilterOperatorSchema)
+      .lazy(() => FilterSchema)
       .array()
       .optional(),
   }),
   z.object({
     $or: z
-      .lazy(() => FilterOperatorSchema)
+      .lazy(() => FilterSchema)
       .array()
       .optional(),
   }),
@@ -121,16 +121,16 @@ export const FilterOperatorSchema = z.union([
 ])
 
 export type TransactionFilter = {
-  [K in keyof Transaction]: FilterOperator
+  [K in keyof Partial<Transaction>]: Filter
 }
 
-export const TransactionFilterSchema = z.record(
+export const TransactionFilterSchema: z.ZodType<TransactionFilter> = z.record(
   z.string(),
-  FilterOperatorSchema,
+  z.lazy(() => FilterSchema),
 )
 
-type Primitive = string | number | boolean
-export const PrimitiveSchema = z.union([z.string(), z.number(), z.boolean()])
+type Primitive = string | number | boolean | bigint
+export const PrimitiveSchema = z.union([z.string(), z.number(), z.boolean(), z.bigint()])
 
 export type FilterObject = {
   [key: string]: Filter
@@ -171,12 +171,14 @@ export const AbiParamFilterSchema = z
 
 export type Filter =
   | Primitive
+  | Array<Primitive>
   | FilterObject
   | FilterArray
   | FilterOperator
   | Abi
 export const FilterSchema = z.union([
   PrimitiveSchema,
+  PrimitiveSchema.array(),
   FilterObjectSchema,
   FilterOperatorSchema,
   z.lazy(() => FilterSchema.array()),
@@ -188,7 +190,7 @@ export const FilterArraySchema = FilterSchema.array()
 
 export type NthFilter = {
   index: bigint | number | string
-  value: TransactionFilter | FilterObject
+  value: TransactionFilter | Filter
 }
 export const NthFilterSchema = z.object({
   index: z.union([z.bigint(), z.number(), z.string()]),

--- a/packages/utils/src/types/filters.ts
+++ b/packages/utils/src/types/filters.ts
@@ -130,7 +130,12 @@ export const TransactionFilterSchema: z.ZodType<TransactionFilter> = z.record(
 )
 
 export type Primitive = string | number | boolean | bigint
-export const PrimitiveSchema = z.union([z.string(), z.number(), z.boolean(), z.bigint()])
+export const PrimitiveSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.bigint(),
+])
 
 export type FilterObject = {
   [key: string]: Filter

--- a/packages/utils/src/types/index.ts
+++ b/packages/utils/src/types/index.ts
@@ -101,6 +101,7 @@ export {
 export { ActionType, OrderType } from './actions'
 
 export type {
+  Primitive,
   FilterObject,
   BitmaskFilter,
   NthFilter,


### PR DESCRIPTION
- use `Filter` as base type for mint action params, supports any combination of:
  - `FilterOperator`
  - `FilterObject`
  - `FilterArray`
  - `Primitive`
  - `PrimitiveArray`
- values of `FilterObject` and `FilterOperator` are now `Filter`, which is not a breaking change because `Filter` includes `FilterOperator`
- support wider range of filter combinations like
```{
  // Logical filter operator  
  "$or": [  
    {
      // FilterObject  
      "to": {
        // Logical filter operator  
        "$or": [
          // Primitive Array  
          "0xfoo",  
          "0xbar"  
        ]  
      },
```