### PR TITLE
[BOOST-4537]feat(uniswap): add LOUDER to swappable token list on uniswap

### DIFF
--- a/.changeset/grumpy-rice-sing.md
+++ b/.changeset/grumpy-rice-sing.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk-plugin-uniswap": patch
+---
+
+add LOUDER to swappable tokens list

--- a/packages/uniswap/src/token-addresses.ts
+++ b/packages/uniswap/src/token-addresses.ts
@@ -71,6 +71,7 @@ const baseTokenAddresses: Address[] = [
   '0x7D12aEb5d96d221071d176980D23c213d88d9998', // FCKN
   '0x4ed4E862860beD51a9570b96d89aF5E1B0Efefed', // DEGEN
   '0x6Ed58e745B41665EA889698de7b2becC9a4A83d7', // ALFAA
+  '0x120edC8E391ba4c94Cb98bb65d8856Ae6eC1525F', // LOUDER
 ]
 
 const arbitrumTokenAddresses: Address[] = [


### PR DESCRIPTION
- adds LOUDER as a swappable token

![CleanShot 2024-08-23 at 18 00 25@2x](https://github.com/user-attachments/assets/b920f1db-aad8-4709-9c6e-2b53ae936c0d)

![CleanShot 2024-08-23 at 18 05 43@2x](https://github.com/user-attachments/assets/62597394-8903-475f-9975-651fb37880bc)
